### PR TITLE
[1팀 이의찬] Chapter 4-2 코드 관점의 성능 최적화

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,6 +5,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
+    'plugin:prettier/recommended',
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,96 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# ESLint cache
+.eslintcache
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# Next.js build output
+.next
+
+# Nuxt.js build / generate output
+.nuxt
+dist
+
+# Gatsby files
+.cache/
+public
+
+# Storybook build outputs
+.out
+.storybook-out
+
+# Temporary folders
+tmp/
+temp/
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Package manager files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,13 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "10주차-성능최적화-2-심화과제",
   "private": true,
   "version": "0.0.0",
+  "homepage": "https://legitgoons.github.io/front_6th_chapter4-2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +13,9 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\""
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "@chakra-ui/icons": "2.2.4",
@@ -44,6 +47,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
+    "gh-pages": "^6.3.0",
     "prettier": "^3.6.2",
     "tsx": "^4.17.0",
     "typescript": "^5.4.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "build": "tsc -b && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint:fix": "eslint . --ext ts,tsx --fix",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\""
   },
   "dependencies": {
     "@chakra-ui/icons": "2.2.4",
@@ -37,8 +40,11 @@
     "@vitest/coverage-v8": "^2.0.3",
     "@vitest/ui": "^1.6.0",
     "eslint": "^8.57.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
+    "prettier": "^3.6.2",
     "tsx": "^4.17.0",
     "typescript": "^5.4.5",
     "vite": "npm:rolldown-vite@latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.7
         version: 0.4.20(eslint@8.57.1)
+      gh-pages:
+        specifier: ^6.3.0
+        version: 6.3.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -1256,6 +1259,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -1328,6 +1334,13 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1412,6 +1425,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  email-addresses@5.0.0:
+    resolution: {integrity: sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1453,6 +1469,10 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1565,12 +1585,28 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  filename-reserved-regex@2.0.0:
+    resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
+    engines: {node: '>=4'}
+
+  filenamify@4.3.0:
+    resolution: {integrity: sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==}
+    engines: {node: '>=8'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-cache-dir@3.3.2:
+    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
+    engines: {node: '>=8'}
+
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -1621,6 +1657,10 @@ packages:
   framesync@6.1.2:
     resolution: {integrity: sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==}
 
+  fs-extra@11.3.1:
+    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
+    engines: {node: '>=14.14'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -1654,6 +1694,11 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
+  gh-pages@6.3.0:
+    resolution: {integrity: sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1685,6 +1730,9 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -1820,6 +1868,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1894,6 +1945,10 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1932,6 +1987,10 @@ packages:
 
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -2021,13 +2080,25 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -2086,6 +2157,10 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
 
   postcss@8.5.4:
     resolution: {integrity: sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==}
@@ -2278,6 +2353,10 @@ packages:
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
@@ -2354,6 +2433,10 @@ packages:
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
+  strip-outer@1.0.1:
+    resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
+    engines: {node: '>=0.10.0'}
+
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
 
@@ -2424,6 +2507,10 @@ packages:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
+  trim-repeated@1.0.0:
+    resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
+    engines: {node: '>=0.10.0'}
+
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -2464,6 +2551,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -3660,6 +3751,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  async@3.2.6: {}
+
   asynckit@0.4.0: {}
 
   axios@1.11.0:
@@ -3740,6 +3833,10 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@13.1.0: {}
+
+  commondir@1.0.1: {}
+
   concat-map@0.0.1: {}
 
   convert-source-map@1.9.0: {}
@@ -3805,6 +3902,8 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  email-addresses@5.0.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3886,6 +3985,8 @@ snapshots:
       '@esbuild/win32-x64': 0.25.5
 
   escalade@3.2.0: {}
+
+  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -4014,11 +4115,30 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  filename-reserved-regex@2.0.0: {}
+
+  filenamify@4.3.0:
+    dependencies:
+      filename-reserved-regex: 2.0.0
+      strip-outer: 1.0.1
+      trim-repeated: 1.0.0
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-cache-dir@3.3.2:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+
   find-root@1.1.0: {}
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   find-up@5.0.0:
     dependencies:
@@ -4066,6 +4186,12 @@ snapshots:
     dependencies:
       tslib: 2.4.0
 
+  fs-extra@11.3.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
@@ -4100,6 +4226,16 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  gh-pages@6.3.0:
+    dependencies:
+      async: 3.2.6
+      commander: 13.1.0
+      email-addresses: 5.0.0
+      filenamify: 4.3.0
+      find-cache-dir: 3.3.2
+      fs-extra: 11.3.1
+      globby: 11.1.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -4143,6 +4279,8 @@ snapshots:
       slash: 3.0.0
 
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
 
@@ -4253,6 +4391,12 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -4309,6 +4453,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -4344,6 +4492,10 @@ snapshots:
       '@babel/parser': 7.27.5
       '@babel/types': 7.27.6
       source-map-js: 1.2.1
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
 
   make-dir@4.0.0:
     dependencies:
@@ -4434,13 +4586,23 @@ snapshots:
 
   outvariant@1.4.3: {}
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -4483,6 +4645,10 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
 
   postcss@8.5.4:
     dependencies:
@@ -4678,6 +4844,8 @@ snapshots:
 
   scheduler@0.26.0: {}
 
+  semver@6.3.1: {}
+
   semver@7.7.2: {}
 
   shebang-command@2.0.0:
@@ -4740,6 +4908,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strip-outer@1.0.1:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
   stylis@4.2.0: {}
 
   supports-color@7.2.0:
@@ -4795,6 +4967,10 @@ snapshots:
     dependencies:
       tldts: 7.0.12
 
+  trim-repeated@1.0.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
   ts-api-utils@1.4.3(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
@@ -4823,6 +4999,8 @@ snapshots:
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
+
+  universalify@2.0.1: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,12 +78,21 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@8.57.1)
+      eslint-plugin-prettier:
+        specifier: ^5.5.4
+        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.6.2)
       eslint-plugin-react-hooks:
         specifier: ^4.6.2
         version: 4.6.2(eslint@8.57.1)
       eslint-plugin-react-refresh:
         specifier: ^0.4.7
         version: 0.4.20(eslint@8.57.1)
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
       tsx:
         specifier: ^4.17.0
         version: 4.19.4
@@ -694,6 +703,10 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1445,6 +1458,26 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
+  eslint-plugin-prettier@5.5.4:
+    resolution: {integrity: sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+
   eslint-plugin-react-hooks@4.6.2:
     resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
     engines: {node: '>=10'}
@@ -1499,6 +1532,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2063,6 +2099,15 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-linter-helpers@1.0.0:
+    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+    engines: {node: '>=6.0.0'}
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -2319,6 +2364,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  synckit@0.11.11:
+    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
@@ -3093,6 +3142,8 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@pkgr/core@0.2.9': {}
+
   '@polka/url@1.0.0-next.29': {}
 
   '@popperjs/core@2.11.8': {}
@@ -3838,6 +3889,19 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-config-prettier@10.1.8(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
+  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.6.2):
+    dependencies:
+      eslint: 8.57.1
+      prettier: 3.6.2
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.11.11
+    optionalDependencies:
+      eslint-config-prettier: 10.1.8(eslint@8.57.1)
+
   eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
@@ -3921,6 +3985,8 @@ snapshots:
   expect-type@1.2.1: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-diff@1.3.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -4432,6 +4498,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier-linter-helpers@1.0.0:
+    dependencies:
+      fast-diff: 1.3.0
+
+  prettier@3.6.2: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4675,6 +4747,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  synckit@0.11.11:
+    dependencies:
+      '@pkgr/core': 0.2.9
 
   test-exclude@7.0.1:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,12 @@
-import { ChakraProvider } from "@chakra-ui/react";
-import { ScheduleProvider } from "./ScheduleContext.tsx";
-import { ScheduleTables } from "./ScheduleTables.tsx";
-import ScheduleDndProvider from "./ScheduleDndProvider.tsx";
+import { ChakraProvider } from '@chakra-ui/react';
+import { ScheduleProvider } from './ScheduleContext.tsx';
+import { ScheduleTables } from './ScheduleTables.tsx';
 
 function App() {
-
   return (
     <ChakraProvider>
       <ScheduleProvider>
-        <ScheduleDndProvider>
-          <ScheduleTables/>
-        </ScheduleDndProvider>
+        <ScheduleTables />
       </ScheduleProvider>
     </ChakraProvider>
   );

--- a/src/LectureTableRow.tsx
+++ b/src/LectureTableRow.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Button, Td, Tr } from '@chakra-ui/react';
+import { Lecture } from './types';
+
+interface LectureTableRowProps {
+  lecture: Lecture;
+  index: number;
+  onAddSchedule: (lecture: Lecture) => void;
+}
+
+const LectureTableRow = React.memo<LectureTableRowProps>(
+  ({ lecture, index, onAddSchedule }) => {
+    return (
+      <Tr key={`${lecture.id}-${index}`}>
+        <Td width="100px">{lecture.id}</Td>
+        <Td width="50px">{lecture.grade}</Td>
+        <Td width="200px">{lecture.title}</Td>
+        <Td width="50px">{lecture.credits}</Td>
+        <Td width="150px" dangerouslySetInnerHTML={{ __html: lecture.major }} />
+        <Td width="150px" dangerouslySetInnerHTML={{ __html: lecture.schedule }} />
+        <Td width="80px">
+          <Button size="sm" colorScheme="green" onClick={() => onAddSchedule(lecture)}>
+            추가
+          </Button>
+        </Td>
+      </Tr>
+    );
+  },
+  (prevProps, nextProps) => {
+    return (
+      prevProps.lecture.id === nextProps.lecture.id &&
+      prevProps.lecture.grade === nextProps.lecture.grade &&
+      prevProps.lecture.title === nextProps.lecture.title &&
+      prevProps.lecture.credits === nextProps.lecture.credits &&
+      prevProps.lecture.major === nextProps.lecture.major &&
+      prevProps.lecture.schedule === nextProps.lecture.schedule &&
+      prevProps.index === nextProps.index
+    );
+  }
+);
+
+export default LectureTableRow;

--- a/src/ScheduleContext.tsx
+++ b/src/ScheduleContext.tsx
@@ -1,6 +1,6 @@
-import React, { createContext, PropsWithChildren, useContext, useState } from "react";
-import { Schedule } from "./types.ts";
-import dummyScheduleMap from "./dummyScheduleMap.ts";
+import React, { createContext, PropsWithChildren, useContext, useState } from 'react';
+import { Schedule } from './types.ts';
+import dummyScheduleMap from './dummyScheduleMap.ts';
 
 interface ScheduleContextType {
   schedulesMap: Record<string, Schedule[]>;

--- a/src/ScheduleContext.tsx
+++ b/src/ScheduleContext.tsx
@@ -1,10 +1,13 @@
-import React, { createContext, PropsWithChildren, useContext, useState } from 'react';
+import { createContext, PropsWithChildren, useContext, useState, useCallback } from 'react';
 import { Schedule } from './types.ts';
 import dummyScheduleMap from './dummyScheduleMap.ts';
 
 interface ScheduleContextType {
-  schedulesMap: Record<string, Schedule[]>;
-  setSchedulesMap: React.Dispatch<React.SetStateAction<Record<string, Schedule[]>>>;
+  initialSchedulesMap: Record<string, Schedule[]>;
+  tableIds: string[];
+  addTable: () => string;
+  duplicateTable: (sourceTableId: string, schedules: Schedule[]) => string;
+  removeTable: (tableId: string) => void;
 }
 
 const ScheduleContext = createContext<ScheduleContextType | undefined>(undefined);
@@ -18,10 +21,35 @@ export const useScheduleContext = () => {
 };
 
 export const ScheduleProvider = ({ children }: PropsWithChildren) => {
-  const [schedulesMap, setSchedulesMap] = useState<Record<string, Schedule[]>>(dummyScheduleMap);
+  const [initialSchedulesMap] = useState<Record<string, Schedule[]>>(dummyScheduleMap);
+  const [tableIds, setTableIds] = useState<string[]>(Object.keys(dummyScheduleMap));
+
+  const addTable = useCallback(() => {
+    const newId = `schedule-${Date.now()}`;
+    setTableIds(prev => [...prev, newId]);
+    return newId;
+  }, []);
+
+  const duplicateTable = useCallback(() => {
+    const newId = `schedule-${Date.now()}`;
+    setTableIds(prev => [...prev, newId]);
+    return newId;
+  }, []);
+
+  const removeTable = useCallback((tableId: string) => {
+    setTableIds(prev => prev.filter(id => id !== tableId));
+  }, []);
 
   return (
-    <ScheduleContext.Provider value={{ schedulesMap, setSchedulesMap }}>
+    <ScheduleContext.Provider
+      value={{
+        initialSchedulesMap,
+        tableIds,
+        addTable,
+        duplicateTable,
+        removeTable,
+      }}
+    >
       {children}
     </ScheduleContext.Provider>
   );

--- a/src/ScheduleDndProvider.tsx
+++ b/src/ScheduleDndProvider.tsx
@@ -1,7 +1,7 @@
 import { DndContext, Modifier, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { PropsWithChildren } from 'react';
 import { CellSize, DAY_LABELS } from './constants.ts';
-import { useScheduleContext } from './ScheduleContext.tsx';
+import { Schedule } from './types.ts';
 
 function createSnapModifier(): Modifier {
   return ({ transform, containerNodeRect, draggingNodeRect }) => {
@@ -30,8 +30,18 @@ function createSnapModifier(): Modifier {
 
 const modifiers = [createSnapModifier()];
 
-export default function ScheduleDndProvider({ children }: PropsWithChildren) {
-  const { schedulesMap, setSchedulesMap } = useScheduleContext();
+interface ScheduleDndProviderProps extends PropsWithChildren {
+  tableId: string;
+  schedules: Schedule[];
+  onSchedulesChange: (schedules: Schedule[]) => void;
+}
+
+export default function ScheduleDndProvider({
+  children,
+  tableId,
+  schedules,
+  onSchedulesChange,
+}: ScheduleDndProviderProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -44,25 +54,27 @@ export default function ScheduleDndProvider({ children }: PropsWithChildren) {
   const handleDragEnd = (event: any) => {
     const { active, delta } = event;
     const { x, y } = delta;
-    const [tableId, index] = active.id.split(':');
-    const schedule = schedulesMap[tableId][index];
+    const [draggedTableId, index] = active.id.split(':');
+
+    if (draggedTableId !== tableId) return;
+
+    const schedule = schedules[index];
     const nowDayIndex = DAY_LABELS.indexOf(schedule.day as (typeof DAY_LABELS)[number]);
     const moveDayIndex = Math.floor(x / 80);
     const moveTimeIndex = Math.floor(y / 30);
 
-    setSchedulesMap({
-      ...schedulesMap,
-      [tableId]: schedulesMap[tableId].map((targetSchedule, targetIndex) => {
-        if (targetIndex !== Number(index)) {
-          return { ...targetSchedule };
-        }
-        return {
-          ...targetSchedule,
-          day: DAY_LABELS[nowDayIndex + moveDayIndex],
-          range: targetSchedule.range.map(time => time + moveTimeIndex),
-        };
-      }),
+    const updatedSchedules = schedules.map((targetSchedule, targetIndex) => {
+      if (targetIndex !== Number(index)) {
+        return { ...targetSchedule };
+      }
+      return {
+        ...targetSchedule,
+        day: DAY_LABELS[nowDayIndex + moveDayIndex],
+        range: targetSchedule.range.map(time => time + moveTimeIndex),
+      };
     });
+
+    onSchedulesChange(updatedSchedules);
   };
 
   return (

--- a/src/ScheduleDndProvider.tsx
+++ b/src/ScheduleDndProvider.tsx
@@ -1,7 +1,7 @@
-import { DndContext, Modifier, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
-import { PropsWithChildren } from "react";
-import { CellSize, DAY_LABELS } from "./constants.ts";
-import { useScheduleContext } from "./ScheduleContext.tsx";
+import { DndContext, Modifier, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { PropsWithChildren } from 'react';
+import { CellSize, DAY_LABELS } from './constants.ts';
+import { useScheduleContext } from './ScheduleContext.tsx';
 
 function createSnapModifier(): Modifier {
   return ({ transform, containerNodeRect, draggingNodeRect }) => {
@@ -17,16 +17,18 @@ function createSnapModifier(): Modifier {
     const maxX = containerRight - right;
     const maxY = containerBottom - bottom;
 
-
-    return ({
+    return {
       ...transform,
       x: Math.min(Math.max(Math.round(transform.x / CellSize.WIDTH) * CellSize.WIDTH, minX), maxX),
-      y: Math.min(Math.max(Math.round(transform.y / CellSize.HEIGHT) * CellSize.HEIGHT, minY), maxY),
-    })
+      y: Math.min(
+        Math.max(Math.round(transform.y / CellSize.HEIGHT) * CellSize.HEIGHT, minY),
+        maxY
+      ),
+    };
   };
 }
 
-const modifiers = [createSnapModifier()]
+const modifiers = [createSnapModifier()];
 
 export default function ScheduleDndProvider({ children }: PropsWithChildren) {
   const { schedulesMap, setSchedulesMap } = useScheduleContext();
@@ -44,7 +46,7 @@ export default function ScheduleDndProvider({ children }: PropsWithChildren) {
     const { x, y } = delta;
     const [tableId, index] = active.id.split(':');
     const schedule = schedulesMap[tableId][index];
-    const nowDayIndex = DAY_LABELS.indexOf(schedule.day as typeof DAY_LABELS[number])
+    const nowDayIndex = DAY_LABELS.indexOf(schedule.day as (typeof DAY_LABELS)[number]);
     const moveDayIndex = Math.floor(x / 80);
     const moveTimeIndex = Math.floor(y / 30);
 
@@ -52,15 +54,15 @@ export default function ScheduleDndProvider({ children }: PropsWithChildren) {
       ...schedulesMap,
       [tableId]: schedulesMap[tableId].map((targetSchedule, targetIndex) => {
         if (targetIndex !== Number(index)) {
-          return { ...targetSchedule }
+          return { ...targetSchedule };
         }
         return {
           ...targetSchedule,
           day: DAY_LABELS[nowDayIndex + moveDayIndex],
           range: targetSchedule.range.map(time => time + moveTimeIndex),
-        }
-      })
-    })
+        };
+      }),
+    });
   };
 
   return (

--- a/src/ScheduleTable.tsx
+++ b/src/ScheduleTable.tsx
@@ -79,7 +79,7 @@ const DraggableSchedule = React.memo(
     const size = range.length;
 
     return (
-      <Popover>
+      <Popover isLazy>
         <PopoverTrigger>
           <Box
             position="absolute"

--- a/src/ScheduleTable.tsx
+++ b/src/ScheduleTable.tsx
@@ -1,9 +1,6 @@
 import {
   Box,
   Button,
-  Flex,
-  Grid,
-  GridItem,
   Popover,
   PopoverArrow,
   PopoverBody,
@@ -12,12 +9,12 @@ import {
   PopoverTrigger,
   Text,
 } from '@chakra-ui/react';
-import { CellSize, DAY_LABELS, 분 } from './constants.ts';
+import { CellSize, DAY_LABELS } from './constants.ts';
 import { Schedule } from './types.ts';
-import { fill2, parseHnM } from './utils.ts';
 import { useDndContext, useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { ComponentProps, Fragment } from 'react';
+import { ComponentProps } from 'react';
+import { ScheduleTableGrid } from './ScheduleTableGrid.tsx';
 
 interface Props {
   tableId: string;
@@ -25,18 +22,6 @@ interface Props {
   onScheduleTimeClick?: (timeInfo: { day: string; time: number }) => void;
   onDeleteButtonClick?: (timeInfo: { day: string; time: number }) => void;
 }
-
-const TIMES = [
-  ...Array(18)
-    .fill(0)
-    .map((v, k) => v + k * 30 * 분)
-    .map(v => `${parseHnM(v)}~${parseHnM(v + 30 * 분)}`),
-
-  ...Array(6)
-    .fill(18 * 30 * 분)
-    .map((v, k) => v + k * 55 * 분)
-    .map(v => `${parseHnM(v)}~${parseHnM(v + 50 * 분)}`),
-] as const;
 
 const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButtonClick }: Props) => {
   const getColor = (lectureId: string): string => {
@@ -47,15 +32,7 @@ const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButton
 
   const dndContext = useDndContext();
 
-  const getActiveTableId = () => {
-    const activeId = dndContext.active?.id;
-    if (activeId) {
-      return String(activeId).split(':')[0];
-    }
-    return null;
-  };
-
-  const activeTableId = getActiveTableId();
+  const activeTableId = String(dndContext.active?.id).split(':')[0] ?? null;
 
   return (
     <Box
@@ -63,55 +40,7 @@ const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButton
       outline={activeTableId === tableId ? '5px dashed' : undefined}
       outlineColor="blue.300"
     >
-      <Grid
-        templateColumns={`120px repeat(${DAY_LABELS.length}, ${CellSize.WIDTH}px)`}
-        templateRows={`40px repeat(${TIMES.length}, ${CellSize.HEIGHT}px)`}
-        bg="white"
-        fontSize="sm"
-        textAlign="center"
-        outline="1px solid"
-        outlineColor="gray.300"
-      >
-        <GridItem key="교시" borderColor="gray.300" bg="gray.100">
-          <Flex justifyContent="center" alignItems="center" h="full" w="full">
-            <Text fontWeight="bold">교시</Text>
-          </Flex>
-        </GridItem>
-        {DAY_LABELS.map(day => (
-          <GridItem key={day} borderLeft="1px" borderColor="gray.300" bg="gray.100">
-            <Flex justifyContent="center" alignItems="center" h="full">
-              <Text fontWeight="bold">{day}</Text>
-            </Flex>
-          </GridItem>
-        ))}
-        {TIMES.map((time, timeIndex) => (
-          <Fragment key={`시간-${timeIndex + 1}`}>
-            <GridItem
-              borderTop="1px solid"
-              borderColor="gray.300"
-              bg={timeIndex > 17 ? 'gray.200' : 'gray.100'}
-            >
-              <Flex justifyContent="center" alignItems="center" h="full">
-                <Text fontSize="xs">
-                  {fill2(timeIndex + 1)} ({time})
-                </Text>
-              </Flex>
-            </GridItem>
-            {DAY_LABELS.map(day => (
-              <GridItem
-                key={`${day}-${timeIndex + 2}`}
-                borderWidth="1px 0 0 1px"
-                borderColor="gray.300"
-                bg={timeIndex > 17 ? 'gray.100' : 'white'}
-                cursor="pointer"
-                _hover={{ bg: 'yellow.100' }}
-                onClick={() => onScheduleTimeClick?.({ day, time: timeIndex + 1 })}
-              />
-            ))}
-          </Fragment>
-        ))}
-      </Grid>
-
+      <ScheduleTableGrid onScheduleTimeClick={onScheduleTimeClick} />
       {schedules.map((schedule, index) => (
         <DraggableSchedule
           key={`${schedule.lecture.title}-${index}`}

--- a/src/ScheduleTable.tsx
+++ b/src/ScheduleTable.tsx
@@ -11,38 +11,37 @@ import {
   PopoverContent,
   PopoverTrigger,
   Text,
-} from "@chakra-ui/react";
-import { CellSize, DAY_LABELS, 분 } from "./constants.ts";
-import { Schedule } from "./types.ts";
-import { fill2, parseHnM } from "./utils.ts";
-import { useDndContext, useDraggable } from "@dnd-kit/core";
-import { CSS } from "@dnd-kit/utilities";
-import { ComponentProps, Fragment } from "react";
+} from '@chakra-ui/react';
+import { CellSize, DAY_LABELS, 분 } from './constants.ts';
+import { Schedule } from './types.ts';
+import { fill2, parseHnM } from './utils.ts';
+import { useDndContext, useDraggable } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
+import { ComponentProps, Fragment } from 'react';
 
 interface Props {
   tableId: string;
   schedules: Schedule[];
-  onScheduleTimeClick?: (timeInfo: { day: string, time: number }) => void;
-  onDeleteButtonClick?: (timeInfo: { day: string, time: number }) => void;
+  onScheduleTimeClick?: (timeInfo: { day: string; time: number }) => void;
+  onDeleteButtonClick?: (timeInfo: { day: string; time: number }) => void;
 }
 
 const TIMES = [
   ...Array(18)
     .fill(0)
     .map((v, k) => v + k * 30 * 분)
-    .map((v) => `${parseHnM(v)}~${parseHnM(v + 30 * 분)}`),
+    .map(v => `${parseHnM(v)}~${parseHnM(v + 30 * 분)}`),
 
   ...Array(6)
     .fill(18 * 30 * 분)
     .map((v, k) => v + k * 55 * 분)
-    .map((v) => `${parseHnM(v)}~${parseHnM(v + 50 * 분)}`),
+    .map(v => `${parseHnM(v)}~${parseHnM(v + 50 * 분)}`),
 ] as const;
 
 const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButtonClick }: Props) => {
-
   const getColor = (lectureId: string): string => {
     const lectures = [...new Set(schedules.map(({ lecture }) => lecture.id))];
-    const colors = ["#fdd", "#ffd", "#dff", "#ddf", "#fdf", "#dfd"];
+    const colors = ['#fdd', '#ffd', '#dff', '#ddf', '#fdf', '#dfd'];
     return colors[lectures.indexOf(lectureId) % colors.length];
   };
 
@@ -51,17 +50,17 @@ const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButton
   const getActiveTableId = () => {
     const activeId = dndContext.active?.id;
     if (activeId) {
-      return String(activeId).split(":")[0];
+      return String(activeId).split(':')[0];
     }
     return null;
-  }
+  };
 
   const activeTableId = getActiveTableId();
 
   return (
     <Box
       position="relative"
-      outline={activeTableId === tableId ? "5px dashed" : undefined}
+      outline={activeTableId === tableId ? '5px dashed' : undefined}
       outlineColor="blue.300"
     >
       <Grid
@@ -78,7 +77,7 @@ const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButton
             <Text fontWeight="bold">교시</Text>
           </Flex>
         </GridItem>
-        {DAY_LABELS.map((day) => (
+        {DAY_LABELS.map(day => (
           <GridItem key={day} borderLeft="1px" borderColor="gray.300" bg="gray.100">
             <Flex justifyContent="center" alignItems="center" h="full">
               <Text fontWeight="bold">{day}</Text>
@@ -93,10 +92,12 @@ const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButton
               bg={timeIndex > 17 ? 'gray.200' : 'gray.100'}
             >
               <Flex justifyContent="center" alignItems="center" h="full">
-                <Text fontSize="xs">{fill2(timeIndex + 1)} ({time})</Text>
+                <Text fontSize="xs">
+                  {fill2(timeIndex + 1)} ({time})
+                </Text>
               </Flex>
             </GridItem>
-            {DAY_LABELS.map((day) => (
+            {DAY_LABELS.map(day => (
               <GridItem
                 key={`${day}-${timeIndex + 2}`}
                 borderWidth="1px 0 0 1px"
@@ -117,10 +118,12 @@ const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButton
           id={`${tableId}:${index}`}
           data={schedule}
           bg={getColor(schedule.lecture.id)}
-          onDeleteButtonClick={() => onDeleteButtonClick?.({
-            day: schedule.day,
-            time: schedule.range[0],
-          })}
+          onDeleteButtonClick={() =>
+            onDeleteButtonClick?.({
+              day: schedule.day,
+              time: schedule.range[0],
+            })
+          }
         />
       ))}
     </Box>
@@ -128,16 +131,16 @@ const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButton
 };
 
 const DraggableSchedule = ({
- id,
- data,
- bg,
- onDeleteButtonClick
+  id,
+  data,
+  bg,
+  onDeleteButtonClick,
 }: { id: string; data: Schedule } & ComponentProps<typeof Box> & {
-  onDeleteButtonClick: () => void
-}) => {
+    onDeleteButtonClick: () => void;
+  }) => {
   const { day, range, room, lecture } = data;
   const { attributes, setNodeRef, listeners, transform } = useDraggable({ id });
-  const leftIndex = DAY_LABELS.indexOf(day as typeof DAY_LABELS[number]);
+  const leftIndex = DAY_LABELS.indexOf(day as (typeof DAY_LABELS)[number]);
   const topIndex = range[0] - 1;
   const size = range.length;
 
@@ -146,10 +149,10 @@ const DraggableSchedule = ({
       <PopoverTrigger>
         <Box
           position="absolute"
-          left={`${120 + (CellSize.WIDTH * leftIndex) + 1}px`}
+          left={`${120 + CellSize.WIDTH * leftIndex + 1}px`}
           top={`${40 + (topIndex * CellSize.HEIGHT + 1)}px`}
-          width={(CellSize.WIDTH - 1) + "px"}
-          height={(CellSize.HEIGHT * size - 1) + "px"}
+          width={CellSize.WIDTH - 1 + 'px'}
+          height={CellSize.HEIGHT * size - 1 + 'px'}
           bg={bg}
           p={1}
           boxSizing="border-box"
@@ -159,13 +162,15 @@ const DraggableSchedule = ({
           {...listeners}
           {...attributes}
         >
-          <Text fontSize="sm" fontWeight="bold">{lecture.title}</Text>
+          <Text fontSize="sm" fontWeight="bold">
+            {lecture.title}
+          </Text>
           <Text fontSize="xs">{room}</Text>
         </Box>
       </PopoverTrigger>
       <PopoverContent onClick={event => event.stopPropagation()}>
-        <PopoverArrow/>
-        <PopoverCloseButton/>
+        <PopoverArrow />
+        <PopoverCloseButton />
         <PopoverBody>
           <Text>강의를 삭제하시겠습니까?</Text>
           <Button colorScheme="red" size="xs" onClick={onDeleteButtonClick}>
@@ -175,6 +180,6 @@ const DraggableSchedule = ({
       </PopoverContent>
     </Popover>
   );
-}
+};
 
 export default ScheduleTable;

--- a/src/ScheduleTable.tsx
+++ b/src/ScheduleTable.tsx
@@ -13,8 +13,9 @@ import { CellSize, DAY_LABELS } from './constants.ts';
 import { Schedule } from './types.ts';
 import { useDndContext, useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { ComponentProps } from 'react';
+import { ComponentProps, useCallback } from 'react';
 import { ScheduleTableGrid } from './ScheduleTableGrid.tsx';
+import React from 'react';
 
 interface Props {
   tableId: string;
@@ -33,6 +34,14 @@ const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButton
   const dndContext = useDndContext();
 
   const activeTableId = String(dndContext.active?.id).split(':')[0] ?? null;
+  const onDeleteButtonClickCallback = useCallback(
+    (schedule: Schedule) =>
+      onDeleteButtonClick?.({
+        day: schedule.day,
+        time: schedule.range[0],
+      }),
+    [onDeleteButtonClick]
+  );
 
   return (
     <Box
@@ -47,68 +56,65 @@ const ScheduleTable = ({ tableId, schedules, onScheduleTimeClick, onDeleteButton
           id={`${tableId}:${index}`}
           data={schedule}
           bg={getColor(schedule.lecture.id)}
-          onDeleteButtonClick={() =>
-            onDeleteButtonClick?.({
-              day: schedule.day,
-              time: schedule.range[0],
-            })
-          }
+          onDeleteButtonClick={onDeleteButtonClickCallback}
         />
       ))}
     </Box>
   );
 };
 
-const DraggableSchedule = ({
-  id,
-  data,
-  bg,
-  onDeleteButtonClick,
-}: { id: string; data: Schedule } & ComponentProps<typeof Box> & {
-    onDeleteButtonClick: () => void;
-  }) => {
-  const { day, range, room, lecture } = data;
-  const { attributes, setNodeRef, listeners, transform } = useDraggable({ id });
-  const leftIndex = DAY_LABELS.indexOf(day as (typeof DAY_LABELS)[number]);
-  const topIndex = range[0] - 1;
-  const size = range.length;
+const DraggableSchedule = React.memo(
+  ({
+    id,
+    data,
+    bg,
+    onDeleteButtonClick,
+  }: { id: string; data: Schedule } & ComponentProps<typeof Box> & {
+      onDeleteButtonClick: (schedule: Schedule) => void;
+    }) => {
+    const { day, range, room, lecture } = data;
+    const { attributes, setNodeRef, listeners, transform } = useDraggable({ id });
+    const leftIndex = DAY_LABELS.indexOf(day as (typeof DAY_LABELS)[number]);
+    const topIndex = range[0] - 1;
+    const size = range.length;
 
-  return (
-    <Popover>
-      <PopoverTrigger>
-        <Box
-          position="absolute"
-          left={`${120 + CellSize.WIDTH * leftIndex + 1}px`}
-          top={`${40 + (topIndex * CellSize.HEIGHT + 1)}px`}
-          width={CellSize.WIDTH - 1 + 'px'}
-          height={CellSize.HEIGHT * size - 1 + 'px'}
-          bg={bg}
-          p={1}
-          boxSizing="border-box"
-          cursor="pointer"
-          ref={setNodeRef}
-          transform={CSS.Translate.toString(transform)}
-          {...listeners}
-          {...attributes}
-        >
-          <Text fontSize="sm" fontWeight="bold">
-            {lecture.title}
-          </Text>
-          <Text fontSize="xs">{room}</Text>
-        </Box>
-      </PopoverTrigger>
-      <PopoverContent onClick={event => event.stopPropagation()}>
-        <PopoverArrow />
-        <PopoverCloseButton />
-        <PopoverBody>
-          <Text>강의를 삭제하시겠습니까?</Text>
-          <Button colorScheme="red" size="xs" onClick={onDeleteButtonClick}>
-            삭제
-          </Button>
-        </PopoverBody>
-      </PopoverContent>
-    </Popover>
-  );
-};
+    return (
+      <Popover>
+        <PopoverTrigger>
+          <Box
+            position="absolute"
+            left={`${120 + CellSize.WIDTH * leftIndex + 1}px`}
+            top={`${40 + (topIndex * CellSize.HEIGHT + 1)}px`}
+            width={CellSize.WIDTH - 1 + 'px'}
+            height={CellSize.HEIGHT * size - 1 + 'px'}
+            bg={bg}
+            p={1}
+            boxSizing="border-box"
+            cursor="pointer"
+            ref={setNodeRef}
+            transform={CSS.Translate.toString(transform)}
+            {...listeners}
+            {...attributes}
+          >
+            <Text fontSize="sm" fontWeight="bold">
+              {lecture.title}
+            </Text>
+            <Text fontSize="xs">{room}</Text>
+          </Box>
+        </PopoverTrigger>
+        <PopoverContent onClick={event => event.stopPropagation()}>
+          <PopoverArrow />
+          <PopoverCloseButton />
+          <PopoverBody>
+            <Text>강의를 삭제하시겠습니까?</Text>
+            <Button colorScheme="red" size="xs" onClick={() => onDeleteButtonClick(data)}>
+              삭제
+            </Button>
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+);
 
 export default ScheduleTable;

--- a/src/ScheduleTableGrid.tsx
+++ b/src/ScheduleTableGrid.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Flex, Grid, GridItem, Text } from '@chakra-ui/react';
+import { Fragment } from 'react/jsx-runtime';
+import { CellSize, DAY_LABELS, 분 } from './constants';
+import { fill2, parseHnM } from './utils';
+
+export const ScheduleTableGrid = React.memo(
+  ({
+    onScheduleTimeClick,
+  }: {
+    onScheduleTimeClick?: (timeInfo: { day: string; time: number }) => void;
+  }) => {
+    const TIMES = [
+      ...Array(18)
+        .fill(0)
+        .map((v, k) => v + k * 30 * 분)
+        .map(v => `${parseHnM(v)}~${parseHnM(v + 30 * 분)}`),
+
+      ...Array(6)
+        .fill(18 * 30 * 분)
+        .map((v, k) => v + k * 55 * 분)
+        .map(v => `${parseHnM(v)}~${parseHnM(v + 50 * 분)}`),
+    ] as const;
+
+    return (
+      <Grid
+        templateColumns={`120px repeat(${DAY_LABELS.length}, ${CellSize.WIDTH}px)`}
+        templateRows={`40px repeat(${TIMES.length}, ${CellSize.HEIGHT}px)`}
+        bg="white"
+        fontSize="sm"
+        textAlign="center"
+        outline="1px solid"
+        outlineColor="gray.300"
+      >
+        <GridItem key="교시" borderColor="gray.300" bg="gray.100">
+          <Flex justifyContent="center" alignItems="center" h="full" w="full">
+            <Text fontWeight="bold">교시</Text>
+          </Flex>
+        </GridItem>
+        {DAY_LABELS.map(day => (
+          <GridItem key={day} borderLeft="1px" borderColor="gray.300" bg="gray.100">
+            <Flex justifyContent="center" alignItems="center" h="full">
+              <Text fontWeight="bold">{day}</Text>
+            </Flex>
+          </GridItem>
+        ))}
+        {TIMES.map((time, timeIndex) => (
+          <Fragment key={`시간-${timeIndex + 1}`}>
+            <GridItem
+              borderTop="1px solid"
+              borderColor="gray.300"
+              bg={timeIndex > 17 ? 'gray.200' : 'gray.100'}
+            >
+              <Flex justifyContent="center" alignItems="center" h="full">
+                <Text fontSize="xs">
+                  {fill2(timeIndex + 1)} ({time})
+                </Text>
+              </Flex>
+            </GridItem>
+            {DAY_LABELS.map(day => (
+              <GridItem
+                key={`${day}-${timeIndex + 2}`}
+                borderWidth="1px 0 0 1px"
+                borderColor="gray.300"
+                bg={timeIndex > 17 ? 'gray.100' : 'white'}
+                cursor="pointer"
+                _hover={{ bg: 'yellow.100' }}
+                onClick={() => onScheduleTimeClick?.({ day, time: timeIndex + 1 })}
+              />
+            ))}
+          </Fragment>
+        ))}
+      </Grid>
+    );
+  }
+);

--- a/src/ScheduleTables.tsx
+++ b/src/ScheduleTables.tsx
@@ -1,8 +1,8 @@
-import { Button, ButtonGroup, Flex, Heading, Stack } from "@chakra-ui/react";
-import ScheduleTable from "./ScheduleTable.tsx";
-import { useScheduleContext } from "./ScheduleContext.tsx";
-import SearchDialog from "./SearchDialog.tsx";
-import { useState } from "react";
+import { Button, ButtonGroup, Flex, Heading, Stack } from '@chakra-ui/react';
+import ScheduleTable from './ScheduleTable.tsx';
+import { useScheduleContext } from './ScheduleContext.tsx';
+import SearchDialog from './SearchDialog.tsx';
+import { useState } from 'react';
 
 export const ScheduleTables = () => {
   const { schedulesMap, setSchedulesMap } = useScheduleContext();
@@ -17,15 +17,15 @@ export const ScheduleTables = () => {
   const duplicate = (targetId: string) => {
     setSchedulesMap(prev => ({
       ...prev,
-      [`schedule-${Date.now()}`]: [...prev[targetId]]
-    }))
+      [`schedule-${Date.now()}`]: [...prev[targetId]],
+    }));
   };
 
   const remove = (targetId: string) => {
     setSchedulesMap(prev => {
       delete prev[targetId];
       return { ...prev };
-    })
+    });
   };
 
   return (
@@ -34,28 +34,43 @@ export const ScheduleTables = () => {
         {Object.entries(schedulesMap).map(([tableId, schedules], index) => (
           <Stack key={tableId} width="600px">
             <Flex justifyContent="space-between" alignItems="center">
-              <Heading as="h3" fontSize="lg">시간표 {index + 1}</Heading>
+              <Heading as="h3" fontSize="lg">
+                시간표 {index + 1}
+              </Heading>
               <ButtonGroup size="sm" isAttached>
-                <Button colorScheme="green" onClick={() => setSearchInfo({ tableId })}>시간표 추가</Button>
-                <Button colorScheme="green" mx="1px" onClick={() => duplicate(tableId)}>복제</Button>
-                <Button colorScheme="green" isDisabled={disabledRemoveButton}
-                        onClick={() => remove(tableId)}>삭제</Button>
+                <Button colorScheme="green" onClick={() => setSearchInfo({ tableId })}>
+                  시간표 추가
+                </Button>
+                <Button colorScheme="green" mx="1px" onClick={() => duplicate(tableId)}>
+                  복제
+                </Button>
+                <Button
+                  colorScheme="green"
+                  isDisabled={disabledRemoveButton}
+                  onClick={() => remove(tableId)}
+                >
+                  삭제
+                </Button>
               </ButtonGroup>
             </Flex>
             <ScheduleTable
               key={`schedule-table-${index}`}
               schedules={schedules}
               tableId={tableId}
-              onScheduleTimeClick={(timeInfo) => setSearchInfo({ tableId, ...timeInfo })}
-              onDeleteButtonClick={({ day, time }) => setSchedulesMap((prev) => ({
-                ...prev,
-                [tableId]: prev[tableId].filter(schedule => schedule.day !== day || !schedule.range.includes(time))
-              }))}
+              onScheduleTimeClick={timeInfo => setSearchInfo({ tableId, ...timeInfo })}
+              onDeleteButtonClick={({ day, time }) =>
+                setSchedulesMap(prev => ({
+                  ...prev,
+                  [tableId]: prev[tableId].filter(
+                    schedule => schedule.day !== day || !schedule.range.includes(time)
+                  ),
+                }))
+              }
             />
           </Stack>
         ))}
       </Flex>
-      <SearchDialog searchInfo={searchInfo} onClose={() => setSearchInfo(null)}/>
+      <SearchDialog searchInfo={searchInfo} onClose={() => setSearchInfo(null)} />
     </>
   );
-}
+};

--- a/src/ScheduleTables.tsx
+++ b/src/ScheduleTables.tsx
@@ -3,6 +3,7 @@ import ScheduleTable from './ScheduleTable.tsx';
 import { useScheduleContext } from './ScheduleContext.tsx';
 import SearchDialog from './SearchDialog.tsx';
 import { useState } from 'react';
+import ScheduleDndProvider from './ScheduleDndProvider.tsx';
 
 export const ScheduleTables = () => {
   const { schedulesMap, setSchedulesMap } = useScheduleContext();
@@ -53,20 +54,22 @@ export const ScheduleTables = () => {
                 </Button>
               </ButtonGroup>
             </Flex>
-            <ScheduleTable
-              key={`schedule-table-${index}`}
-              schedules={schedules}
-              tableId={tableId}
-              onScheduleTimeClick={timeInfo => setSearchInfo({ tableId, ...timeInfo })}
-              onDeleteButtonClick={({ day, time }) =>
-                setSchedulesMap(prev => ({
-                  ...prev,
-                  [tableId]: prev[tableId].filter(
-                    schedule => schedule.day !== day || !schedule.range.includes(time)
-                  ),
-                }))
-              }
-            />
+            <ScheduleDndProvider>
+              <ScheduleTable
+                key={`schedule-table-${index}`}
+                schedules={schedules}
+                tableId={tableId}
+                onScheduleTimeClick={timeInfo => setSearchInfo({ tableId, ...timeInfo })}
+                onDeleteButtonClick={({ day, time }) =>
+                  setSchedulesMap(prev => ({
+                    ...prev,
+                    [tableId]: prev[tableId].filter(
+                      schedule => schedule.day !== day || !schedule.range.includes(time)
+                    ),
+                  }))
+                }
+              />
+            </ScheduleDndProvider>
           </Stack>
         ))}
       </Flex>

--- a/src/ScheduleTables.tsx
+++ b/src/ScheduleTables.tsx
@@ -1,79 +1,15 @@
-import { Button, ButtonGroup, Flex, Heading, Stack } from '@chakra-ui/react';
-import ScheduleTable from './ScheduleTable.tsx';
+import { Flex } from '@chakra-ui/react';
 import { useScheduleContext } from './ScheduleContext.tsx';
-import SearchDialog from './SearchDialog.tsx';
-import { useState } from 'react';
-import ScheduleDndProvider from './ScheduleDndProvider.tsx';
+import TableWrapper from './TableWrapper.tsx';
 
 export const ScheduleTables = () => {
-  const { schedulesMap, setSchedulesMap } = useScheduleContext();
-  const [searchInfo, setSearchInfo] = useState<{
-    tableId: string;
-    day?: string;
-    time?: number;
-  } | null>(null);
-
-  const disabledRemoveButton = Object.keys(schedulesMap).length === 1;
-
-  const duplicate = (targetId: string) => {
-    setSchedulesMap(prev => ({
-      ...prev,
-      [`schedule-${Date.now()}`]: [...prev[targetId]],
-    }));
-  };
-
-  const remove = (targetId: string) => {
-    setSchedulesMap(prev => {
-      delete prev[targetId];
-      return { ...prev };
-    });
-  };
+  const { tableIds } = useScheduleContext();
 
   return (
-    <>
-      <Flex w="full" gap={6} p={6} flexWrap="wrap">
-        {Object.entries(schedulesMap).map(([tableId, schedules], index) => (
-          <Stack key={tableId} width="600px">
-            <Flex justifyContent="space-between" alignItems="center">
-              <Heading as="h3" fontSize="lg">
-                시간표 {index + 1}
-              </Heading>
-              <ButtonGroup size="sm" isAttached>
-                <Button colorScheme="green" onClick={() => setSearchInfo({ tableId })}>
-                  시간표 추가
-                </Button>
-                <Button colorScheme="green" mx="1px" onClick={() => duplicate(tableId)}>
-                  복제
-                </Button>
-                <Button
-                  colorScheme="green"
-                  isDisabled={disabledRemoveButton}
-                  onClick={() => remove(tableId)}
-                >
-                  삭제
-                </Button>
-              </ButtonGroup>
-            </Flex>
-            <ScheduleDndProvider>
-              <ScheduleTable
-                key={`schedule-table-${index}`}
-                schedules={schedules}
-                tableId={tableId}
-                onScheduleTimeClick={timeInfo => setSearchInfo({ tableId, ...timeInfo })}
-                onDeleteButtonClick={({ day, time }) =>
-                  setSchedulesMap(prev => ({
-                    ...prev,
-                    [tableId]: prev[tableId].filter(
-                      schedule => schedule.day !== day || !schedule.range.includes(time)
-                    ),
-                  }))
-                }
-              />
-            </ScheduleDndProvider>
-          </Stack>
-        ))}
-      </Flex>
-      <SearchDialog searchInfo={searchInfo} onClose={() => setSearchInfo(null)} />
-    </>
+    <Flex w="full" gap={6} p={6} flexWrap="wrap">
+      {tableIds.map((tableId, index) => (
+        <TableWrapper key={tableId} tableId={tableId} index={index} />
+      ))}
+    </Flex>
   );
 };

--- a/src/SearchDialog.tsx
+++ b/src/SearchDialog.tsx
@@ -130,10 +130,10 @@ const SearchDialog = ({ searchInfo, onClose, onScheduleAdd }: Props) => {
   const changeSearchOption = useCallback(
     (field: keyof SearchOption, value: SearchOption[typeof field]) => {
       setPage(1);
-      setSearchOptions({ ...searchOptions, [field]: value });
+      setSearchOptions(prev => ({ ...prev, [field]: value }));
       loaderWrapperRef.current?.scrollTo(0, 0);
     },
-    [searchOptions]
+    []
   );
 
   const addSchedule = (lecture: Lecture) => {

--- a/src/SearchDialog.tsx
+++ b/src/SearchDialog.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
-  Button,
   HStack,
   Modal,
   ModalBody,
@@ -11,7 +10,6 @@ import {
   ModalOverlay,
   Table,
   Tbody,
-  Td,
   Text,
   Th,
   Thead,
@@ -27,6 +25,7 @@ import FormGrades from './form/FormGrades.tsx';
 import FormDays from './form/FormDays.tsx';
 import FormTimes from './form/FormTimes.tsx';
 import FormMajors from './form/FormMajors.tsx';
+import LectureTableRow from './LectureTableRow.tsx';
 
 interface Props {
   searchInfo: {
@@ -136,17 +135,20 @@ const SearchDialog = ({ searchInfo, onClose, onScheduleAdd }: Props) => {
     []
   );
 
-  const addSchedule = (lecture: Lecture) => {
-    if (!searchInfo) return;
+  const addSchedule = useCallback(
+    (lecture: Lecture) => {
+      if (!searchInfo) return;
 
-    const schedules = parseSchedule(lecture.schedule).map(schedule => ({
-      ...schedule,
-      lecture,
-    }));
+      const schedules = parseSchedule(lecture.schedule).map(schedule => ({
+        ...schedule,
+        lecture,
+      }));
 
-    onScheduleAdd(schedules);
-    onClose();
-  };
+      onScheduleAdd(schedules);
+      onClose();
+    },
+    [searchInfo, onScheduleAdd, onClose]
+  );
 
   useEffect(() => {
     const start = performance.now();
@@ -244,23 +246,12 @@ const SearchDialog = ({ searchInfo, onClose, onScheduleAdd }: Props) => {
                 <Table size="sm" variant="striped">
                   <Tbody>
                     {visibleLectures.map((lecture, index) => (
-                      <Tr key={`${lecture.id}-${index}`}>
-                        <Td width="100px">{lecture.id}</Td>
-                        <Td width="50px">{lecture.grade}</Td>
-                        <Td width="200px">{lecture.title}</Td>
-                        <Td width="50px">{lecture.credits}</Td>
-                        <Td width="150px" dangerouslySetInnerHTML={{ __html: lecture.major }} />
-                        <Td width="150px" dangerouslySetInnerHTML={{ __html: lecture.schedule }} />
-                        <Td width="80px">
-                          <Button
-                            size="sm"
-                            colorScheme="green"
-                            onClick={() => addSchedule(lecture)}
-                          >
-                            추가
-                          </Button>
-                        </Td>
-                      </Tr>
+                      <LectureTableRow
+                        key={`${lecture.id}-${index}`}
+                        lecture={lecture}
+                        index={index}
+                        onAddSchedule={addSchedule}
+                      />
                     ))}
                   </Tbody>
                 </Table>

--- a/src/SearchDialog.tsx
+++ b/src/SearchDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
   Button,
@@ -95,7 +95,7 @@ const SearchDialog = ({ searchInfo, onClose, onScheduleAdd }: Props) => {
     majors: [],
   });
 
-  const getFilteredLectures = () => {
+  const getFilteredLectures = useCallback(() => {
     const { query = '', credits, grades, days, times, majors } = searchOptions;
     return lectures
       .filter(
@@ -120,12 +120,12 @@ const SearchDialog = ({ searchInfo, onClose, onScheduleAdd }: Props) => {
         const schedules = lecture.schedule ? parseSchedule(lecture.schedule) : [];
         return schedules.some(s => s.range.some(time => times.includes(time)));
       });
-  };
+  }, [searchOptions, lectures]);
 
   const filteredLectures = getFilteredLectures();
   const lastPage = Math.ceil(filteredLectures.length / PAGE_SIZE);
   const visibleLectures = filteredLectures.slice(0, page * PAGE_SIZE);
-  const allMajors = [...new Set(lectures.map(lecture => lecture.major))];
+  const allMajors = useMemo(() => [...new Set(lectures.map(lecture => lecture.major))], [lectures]);
 
   const changeSearchOption = useCallback(
     (field: keyof SearchOption, value: SearchOption[typeof field]) => {

--- a/src/SearchDialog.tsx
+++ b/src/SearchDialog.tsx
@@ -53,14 +53,14 @@ const createCachedFetch = () => {
 
   const fetchMajors = () => {
     if (!cache.has('majors')) {
-      cache.set('majors', axios.get<Lecture[]>('/schedules-majors.json'));
+      cache.set('majors', axios.get<Lecture[]>('./schedules-majors.json'));
     }
     return cache.get('majors')!;
   };
 
   const fetchLiberalArts = () => {
     if (!cache.has('liberal-arts')) {
-      cache.set('liberal-arts', axios.get<Lecture[]>('/schedules-liberal-arts.json'));
+      cache.set('liberal-arts', axios.get<Lecture[]>('./schedules-liberal-arts.json'));
     }
     return cache.get('liberal-arts')!;
   };

--- a/src/SearchDialog.tsx
+++ b/src/SearchDialog.tsx
@@ -85,15 +85,14 @@ const PAGE_SIZE = 100;
 const fetchMajors = () => axios.get<Lecture[]>('/schedules-majors.json');
 const fetchLiberalArts = () => axios.get<Lecture[]>('/schedules-liberal-arts.json');
 
-// TODO: 이 코드를 개선해서 API 호출을 최소화 해보세요 + Promise.all이 현재 잘못 사용되고 있습니다. 같이 개선해주세요.
 const fetchAllLectures = async () =>
   await Promise.all([
-    (console.log('API Call 1', performance.now()), await fetchMajors()),
-    (console.log('API Call 2', performance.now()), await fetchLiberalArts()),
-    (console.log('API Call 3', performance.now()), await fetchMajors()),
-    (console.log('API Call 4', performance.now()), await fetchLiberalArts()),
-    (console.log('API Call 5', performance.now()), await fetchMajors()),
-    (console.log('API Call 6', performance.now()), await fetchLiberalArts()),
+    (console.log('API Call 1', performance.now()), fetchMajors()),
+    (console.log('API Call 2', performance.now()), fetchLiberalArts()),
+    (console.log('API Call 3', performance.now()), fetchMajors()),
+    (console.log('API Call 4', performance.now()), fetchLiberalArts()),
+    (console.log('API Call 5', performance.now()), fetchMajors()),
+    (console.log('API Call 6', performance.now()), fetchLiberalArts()),
   ]);
 
 // TODO: 이 컴포넌트에서 불필요한 연산이 발생하지 않도록 다양한 방식으로 시도해주세요.

--- a/src/SearchDialog.tsx
+++ b/src/SearchDialog.tsx
@@ -1,25 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Box,
   Button,
-  Checkbox,
-  CheckboxGroup,
-  FormControl,
-  FormLabel,
   HStack,
-  Input,
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
-  Select,
-  Stack,
   Table,
-  Tag,
-  TagCloseButton,
-  TagLabel,
   Tbody,
   Td,
   Text,
@@ -27,12 +17,16 @@ import {
   Thead,
   Tr,
   VStack,
-  Wrap,
 } from '@chakra-ui/react';
 import { Lecture, Schedule } from './types.ts';
 import { parseSchedule } from './utils.ts';
 import axios, { AxiosResponse } from 'axios';
-import { DAY_LABELS } from './constants.ts';
+import FormSearch from './form/FormSearch.tsx';
+import FormCredits from './form/FormCredits.tsx';
+import FormGrades from './form/FormGrades.tsx';
+import FormDays from './form/FormDays.tsx';
+import FormTimes from './form/FormTimes.tsx';
+import FormMajors from './form/FormMajors.tsx';
 
 interface Props {
   searchInfo: {
@@ -44,7 +38,7 @@ interface Props {
   onScheduleAdd: (schedules: Schedule[]) => void;
 }
 
-interface SearchOption {
+export interface SearchOption {
   query?: string;
   grades: number[];
   days: string[];
@@ -52,33 +46,6 @@ interface SearchOption {
   majors: string[];
   credits?: number;
 }
-
-const TIME_SLOTS = [
-  { id: 1, label: '09:00~09:30' },
-  { id: 2, label: '09:30~10:00' },
-  { id: 3, label: '10:00~10:30' },
-  { id: 4, label: '10:30~11:00' },
-  { id: 5, label: '11:00~11:30' },
-  { id: 6, label: '11:30~12:00' },
-  { id: 7, label: '12:00~12:30' },
-  { id: 8, label: '12:30~13:00' },
-  { id: 9, label: '13:00~13:30' },
-  { id: 10, label: '13:30~14:00' },
-  { id: 11, label: '14:00~14:30' },
-  { id: 12, label: '14:30~15:00' },
-  { id: 13, label: '15:00~15:30' },
-  { id: 14, label: '15:30~16:00' },
-  { id: 15, label: '16:00~16:30' },
-  { id: 16, label: '16:30~17:00' },
-  { id: 17, label: '17:00~17:30' },
-  { id: 18, label: '17:30~18:00' },
-  { id: 19, label: '18:00~18:50' },
-  { id: 20, label: '18:55~19:45' },
-  { id: 21, label: '19:50~20:40' },
-  { id: 22, label: '20:45~21:35' },
-  { id: 23, label: '21:40~22:30' },
-  { id: 24, label: '22:35~23:25' },
-];
 
 const PAGE_SIZE = 100;
 
@@ -160,11 +127,14 @@ const SearchDialog = ({ searchInfo, onClose, onScheduleAdd }: Props) => {
   const visibleLectures = filteredLectures.slice(0, page * PAGE_SIZE);
   const allMajors = [...new Set(lectures.map(lecture => lecture.major))];
 
-  const changeSearchOption = (field: keyof SearchOption, value: SearchOption[typeof field]) => {
-    setPage(1);
-    setSearchOptions({ ...searchOptions, [field]: value });
-    loaderWrapperRef.current?.scrollTo(0, 0);
-  };
+  const changeSearchOption = useCallback(
+    (field: keyof SearchOption, value: SearchOption[typeof field]) => {
+      setPage(1);
+      setSearchOptions({ ...searchOptions, [field]: value });
+      loaderWrapperRef.current?.scrollTo(0, 0);
+    },
+    [searchOptions]
+  );
 
   const addSchedule = (lecture: Lecture) => {
     if (!searchInfo) return;
@@ -229,149 +199,30 @@ const SearchDialog = ({ searchInfo, onClose, onScheduleAdd }: Props) => {
         <ModalBody>
           <VStack spacing={4} align="stretch">
             <HStack spacing={4}>
-              <FormControl>
-                <FormLabel>검색어</FormLabel>
-                <Input
-                  placeholder="과목명 또는 과목코드"
-                  value={searchOptions.query}
-                  onChange={e => changeSearchOption('query', e.target.value)}
-                />
-              </FormControl>
-
-              <FormControl>
-                <FormLabel>학점</FormLabel>
-                <Select
-                  value={searchOptions.credits}
-                  onChange={e => changeSearchOption('credits', e.target.value)}
-                >
-                  <option value="">전체</option>
-                  <option value="1">1학점</option>
-                  <option value="2">2학점</option>
-                  <option value="3">3학점</option>
-                </Select>
-              </FormControl>
+              <FormSearch
+                query={searchOptions.query}
+                changeSearchOption={changeSearchOption}
+                formLabel="검색어"
+                placeholder="과목명 또는 과목코드"
+              />
+              <FormCredits
+                credits={searchOptions.credits}
+                changeSearchOption={changeSearchOption}
+              />
             </HStack>
 
             <HStack spacing={4}>
-              <FormControl>
-                <FormLabel>학년</FormLabel>
-                <CheckboxGroup
-                  value={searchOptions.grades}
-                  onChange={value => changeSearchOption('grades', value.map(Number))}
-                >
-                  <HStack spacing={4}>
-                    {[1, 2, 3, 4].map(grade => (
-                      <Checkbox key={grade} value={grade}>
-                        {grade}학년
-                      </Checkbox>
-                    ))}
-                  </HStack>
-                </CheckboxGroup>
-              </FormControl>
-
-              <FormControl>
-                <FormLabel>요일</FormLabel>
-                <CheckboxGroup
-                  value={searchOptions.days}
-                  onChange={value => changeSearchOption('days', value as string[])}
-                >
-                  <HStack spacing={4}>
-                    {DAY_LABELS.map(day => (
-                      <Checkbox key={day} value={day}>
-                        {day}
-                      </Checkbox>
-                    ))}
-                  </HStack>
-                </CheckboxGroup>
-              </FormControl>
+              <FormGrades grades={searchOptions.grades} changeSearchOption={changeSearchOption} />
+              <FormDays days={searchOptions.days} changeSearchOption={changeSearchOption} />
             </HStack>
 
             <HStack spacing={4}>
-              <FormControl>
-                <FormLabel>시간</FormLabel>
-                <CheckboxGroup
-                  colorScheme="green"
-                  value={searchOptions.times}
-                  onChange={values => changeSearchOption('times', values.map(Number))}
-                >
-                  <Wrap spacing={1} mb={2}>
-                    {searchOptions.times
-                      .sort((a, b) => a - b)
-                      .map(time => (
-                        <Tag key={time} size="sm" variant="outline" colorScheme="blue">
-                          <TagLabel>{time}교시</TagLabel>
-                          <TagCloseButton
-                            onClick={() =>
-                              changeSearchOption(
-                                'times',
-                                searchOptions.times.filter(v => v !== time)
-                              )
-                            }
-                          />
-                        </Tag>
-                      ))}
-                  </Wrap>
-                  <Stack
-                    spacing={2}
-                    overflowY="auto"
-                    h="100px"
-                    border="1px solid"
-                    borderColor="gray.200"
-                    borderRadius={5}
-                    p={2}
-                  >
-                    {TIME_SLOTS.map(({ id, label }) => (
-                      <Box key={id}>
-                        <Checkbox key={id} size="sm" value={id}>
-                          {id}교시({label})
-                        </Checkbox>
-                      </Box>
-                    ))}
-                  </Stack>
-                </CheckboxGroup>
-              </FormControl>
-
-              <FormControl>
-                <FormLabel>전공</FormLabel>
-                <CheckboxGroup
-                  colorScheme="green"
-                  value={searchOptions.majors}
-                  onChange={values => changeSearchOption('majors', values as string[])}
-                >
-                  <Wrap spacing={1} mb={2}>
-                    {searchOptions.majors.map(major => (
-                      <Tag key={major} size="sm" variant="outline" colorScheme="blue">
-                        <TagLabel>{major.split('<p>').pop()}</TagLabel>
-                        <TagCloseButton
-                          onClick={() =>
-                            changeSearchOption(
-                              'majors',
-                              searchOptions.majors.filter(v => v !== major)
-                            )
-                          }
-                        />
-                      </Tag>
-                    ))}
-                  </Wrap>
-                  <Stack
-                    spacing={2}
-                    overflowY="auto"
-                    h="100px"
-                    border="1px solid"
-                    borderColor="gray.200"
-                    borderRadius={5}
-                    p={2}
-                  >
-                    {allMajors.map(major => (
-                      <Box key={major}>
-                        <Checkbox key={major} size="sm" value={major}>
-                          {major.replace(/<p>/gi, ' ')}
-                        </Checkbox>
-                      </Box>
-                    ))}
-                  </Stack>
-                </CheckboxGroup>
-              </FormControl>
+              <FormTimes times={searchOptions.times} changeSearchOption={changeSearchOption} />
+              <FormMajors
+                majors={searchOptions.majors}
+                allMajors={allMajors}
+                changeSearchOption={changeSearchOption}
+              />
             </HStack>
             <Text align="right">검색결과: {filteredLectures.length}개</Text>
             <Box>

--- a/src/SearchDialog.tsx
+++ b/src/SearchDialog.tsx
@@ -31,7 +31,7 @@ import {
 } from '@chakra-ui/react';
 import { Lecture, Schedule } from './types.ts';
 import { parseSchedule } from './utils.ts';
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import { DAY_LABELS } from './constants.ts';
 
 interface Props {
@@ -82,8 +82,27 @@ const TIME_SLOTS = [
 
 const PAGE_SIZE = 100;
 
-const fetchMajors = () => axios.get<Lecture[]>('/schedules-majors.json');
-const fetchLiberalArts = () => axios.get<Lecture[]>('/schedules-liberal-arts.json');
+const createCachedFetch = () => {
+  const cache = new Map<string, Promise<AxiosResponse<Lecture[]>>>();
+
+  const fetchMajors = () => {
+    if (!cache.has('majors')) {
+      cache.set('majors', axios.get<Lecture[]>('/schedules-majors.json'));
+    }
+    return cache.get('majors')!;
+  };
+
+  const fetchLiberalArts = () => {
+    if (!cache.has('liberal-arts')) {
+      cache.set('liberal-arts', axios.get<Lecture[]>('/schedules-liberal-arts.json'));
+    }
+    return cache.get('liberal-arts')!;
+  };
+
+  return { fetchMajors, fetchLiberalArts };
+};
+
+const { fetchMajors, fetchLiberalArts } = createCachedFetch();
 
 const fetchAllLectures = async () =>
   await Promise.all([

--- a/src/SearchDialog.tsx
+++ b/src/SearchDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from 'react';
 import {
   Box,
   Button,
@@ -28,12 +28,12 @@ import {
   Tr,
   VStack,
   Wrap,
-} from "@chakra-ui/react";
-import { useScheduleContext } from "./ScheduleContext.tsx";
-import { Lecture } from "./types.ts";
-import { parseSchedule } from "./utils.ts";
-import axios from "axios";
-import { DAY_LABELS } from "./constants.ts";
+} from '@chakra-ui/react';
+import { useScheduleContext } from './ScheduleContext.tsx';
+import { Lecture } from './types.ts';
+import { parseSchedule } from './utils.ts';
+import axios from 'axios';
+import { DAY_LABELS } from './constants.ts';
 
 interface Props {
   searchInfo: {
@@ -45,39 +45,39 @@ interface Props {
 }
 
 interface SearchOption {
-  query?: string,
-  grades: number[],
-  days: string[],
-  times: number[],
-  majors: string[],
-  credits?: number,
+  query?: string;
+  grades: number[];
+  days: string[];
+  times: number[];
+  majors: string[];
+  credits?: number;
 }
 
 const TIME_SLOTS = [
-  { id: 1, label: "09:00~09:30" },
-  { id: 2, label: "09:30~10:00" },
-  { id: 3, label: "10:00~10:30" },
-  { id: 4, label: "10:30~11:00" },
-  { id: 5, label: "11:00~11:30" },
-  { id: 6, label: "11:30~12:00" },
-  { id: 7, label: "12:00~12:30" },
-  { id: 8, label: "12:30~13:00" },
-  { id: 9, label: "13:00~13:30" },
-  { id: 10, label: "13:30~14:00" },
-  { id: 11, label: "14:00~14:30" },
-  { id: 12, label: "14:30~15:00" },
-  { id: 13, label: "15:00~15:30" },
-  { id: 14, label: "15:30~16:00" },
-  { id: 15, label: "16:00~16:30" },
-  { id: 16, label: "16:30~17:00" },
-  { id: 17, label: "17:00~17:30" },
-  { id: 18, label: "17:30~18:00" },
-  { id: 19, label: "18:00~18:50" },
-  { id: 20, label: "18:55~19:45" },
-  { id: 21, label: "19:50~20:40" },
-  { id: 22, label: "20:45~21:35" },
-  { id: 23, label: "21:40~22:30" },
-  { id: 24, label: "22:35~23:25" },
+  { id: 1, label: '09:00~09:30' },
+  { id: 2, label: '09:30~10:00' },
+  { id: 3, label: '10:00~10:30' },
+  { id: 4, label: '10:30~11:00' },
+  { id: 5, label: '11:00~11:30' },
+  { id: 6, label: '11:30~12:00' },
+  { id: 7, label: '12:00~12:30' },
+  { id: 8, label: '12:30~13:00' },
+  { id: 9, label: '13:00~13:30' },
+  { id: 10, label: '13:30~14:00' },
+  { id: 11, label: '14:00~14:30' },
+  { id: 12, label: '14:30~15:00' },
+  { id: 13, label: '15:00~15:30' },
+  { id: 14, label: '15:30~16:00' },
+  { id: 15, label: '16:00~16:30' },
+  { id: 16, label: '16:30~17:00' },
+  { id: 17, label: '17:00~17:30' },
+  { id: 18, label: '17:30~18:00' },
+  { id: 19, label: '18:00~18:50' },
+  { id: 20, label: '18:55~19:45' },
+  { id: 21, label: '19:50~20:40' },
+  { id: 22, label: '20:45~21:35' },
+  { id: 23, label: '21:40~22:30' },
+  { id: 24, label: '22:35~23:25' },
 ];
 
 const PAGE_SIZE = 100;
@@ -86,14 +86,15 @@ const fetchMajors = () => axios.get<Lecture[]>('/schedules-majors.json');
 const fetchLiberalArts = () => axios.get<Lecture[]>('/schedules-liberal-arts.json');
 
 // TODO: 이 코드를 개선해서 API 호출을 최소화 해보세요 + Promise.all이 현재 잘못 사용되고 있습니다. 같이 개선해주세요.
-const fetchAllLectures = async () => await Promise.all([
-  (console.log('API Call 1', performance.now()), await fetchMajors()),
-  (console.log('API Call 2', performance.now()), await fetchLiberalArts()),
-  (console.log('API Call 3', performance.now()), await fetchMajors()),
-  (console.log('API Call 4', performance.now()), await fetchLiberalArts()),
-  (console.log('API Call 5', performance.now()), await fetchMajors()),
-  (console.log('API Call 6', performance.now()), await fetchLiberalArts()),
-]);
+const fetchAllLectures = async () =>
+  await Promise.all([
+    (console.log('API Call 1', performance.now()), await fetchMajors()),
+    (console.log('API Call 2', performance.now()), await fetchLiberalArts()),
+    (console.log('API Call 3', performance.now()), await fetchMajors()),
+    (console.log('API Call 4', performance.now()), await fetchLiberalArts()),
+    (console.log('API Call 5', performance.now()), await fetchMajors()),
+    (console.log('API Call 6', performance.now()), await fetchLiberalArts()),
+  ]);
 
 // TODO: 이 컴포넌트에서 불필요한 연산이 발생하지 않도록 다양한 방식으로 시도해주세요.
 const SearchDialog = ({ searchInfo, onClose }: Props) => {
@@ -114,9 +115,10 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
   const getFilteredLectures = () => {
     const { query = '', credits, grades, days, times, majors } = searchOptions;
     return lectures
-      .filter(lecture =>
-        lecture.title.toLowerCase().includes(query.toLowerCase()) ||
-        lecture.id.toLowerCase().includes(query.toLowerCase())
+      .filter(
+        lecture =>
+          lecture.title.toLowerCase().includes(query.toLowerCase()) ||
+          lecture.id.toLowerCase().includes(query.toLowerCase())
       )
       .filter(lecture => grades.length === 0 || grades.includes(lecture.grade))
       .filter(lecture => majors.length === 0 || majors.includes(lecture.major))
@@ -135,7 +137,7 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
         const schedules = lecture.schedule ? parseSchedule(lecture.schedule) : [];
         return schedules.some(s => s.range.some(time => times.includes(time)));
       });
-  }
+  };
 
   const filteredLectures = getFilteredLectures();
   const lastPage = Math.ceil(filteredLectures.length / PAGE_SIZE);
@@ -144,7 +146,7 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
 
   const changeSearchOption = (field: keyof SearchOption, value: SearchOption[typeof field]) => {
     setPage(1);
-    setSearchOptions(({ ...searchOptions, [field]: value }));
+    setSearchOptions({ ...searchOptions, [field]: value });
     loaderWrapperRef.current?.scrollTo(0, 0);
   };
 
@@ -155,12 +157,12 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
 
     const schedules = parseSchedule(lecture.schedule).map(schedule => ({
       ...schedule,
-      lecture
+      lecture,
     }));
 
     setSchedulesMap(prev => ({
       ...prev,
-      [tableId]: [...prev[tableId], ...schedules]
+      [tableId]: [...prev[tableId], ...schedules],
     }));
 
     onClose();
@@ -168,13 +170,13 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
 
   useEffect(() => {
     const start = performance.now();
-    console.log('API 호출 시작: ', start)
+    console.log('API 호출 시작: ', start);
     fetchAllLectures().then(results => {
       const end = performance.now();
-      console.log('모든 API 호출 완료 ', end)
-      console.log('API 호출에 걸린 시간(ms): ', end - start)
+      console.log('모든 API 호출 완료 ', end);
+      console.log('API 호출에 걸린 시간(ms): ', end - start);
       setLectures(results.flatMap(result => result.data));
-    })
+    });
   }, []);
 
   useEffect(() => {
@@ -204,16 +206,16 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
       ...prev,
       days: searchInfo?.day ? [searchInfo.day] : [],
       times: searchInfo?.time ? [searchInfo.time] : [],
-    }))
+    }));
     setPage(1);
   }, [searchInfo]);
 
   return (
     <Modal isOpen={Boolean(searchInfo)} onClose={onClose} size="6xl">
-      <ModalOverlay/>
+      <ModalOverlay />
       <ModalContent maxW="90vw" w="1000px">
         <ModalHeader>수업 검색</ModalHeader>
-        <ModalCloseButton/>
+        <ModalCloseButton />
         <ModalBody>
           <VStack spacing={4} align="stretch">
             <HStack spacing={4}>
@@ -222,7 +224,7 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
                 <Input
                   placeholder="과목명 또는 과목코드"
                   value={searchOptions.query}
-                  onChange={(e) => changeSearchOption('query', e.target.value)}
+                  onChange={e => changeSearchOption('query', e.target.value)}
                 />
               </FormControl>
 
@@ -230,7 +232,7 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
                 <FormLabel>학점</FormLabel>
                 <Select
                   value={searchOptions.credits}
-                  onChange={(e) => changeSearchOption('credits', e.target.value)}
+                  onChange={e => changeSearchOption('credits', e.target.value)}
                 >
                   <option value="">전체</option>
                   <option value="1">1학점</option>
@@ -245,11 +247,13 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
                 <FormLabel>학년</FormLabel>
                 <CheckboxGroup
                   value={searchOptions.grades}
-                  onChange={(value) => changeSearchOption('grades', value.map(Number))}
+                  onChange={value => changeSearchOption('grades', value.map(Number))}
                 >
                   <HStack spacing={4}>
                     {[1, 2, 3, 4].map(grade => (
-                      <Checkbox key={grade} value={grade}>{grade}학년</Checkbox>
+                      <Checkbox key={grade} value={grade}>
+                        {grade}학년
+                      </Checkbox>
                     ))}
                   </HStack>
                 </CheckboxGroup>
@@ -259,11 +263,13 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
                 <FormLabel>요일</FormLabel>
                 <CheckboxGroup
                   value={searchOptions.days}
-                  onChange={(value) => changeSearchOption('days', value as string[])}
+                  onChange={value => changeSearchOption('days', value as string[])}
                 >
                   <HStack spacing={4}>
                     {DAY_LABELS.map(day => (
-                      <Checkbox key={day} value={day}>{day}</Checkbox>
+                      <Checkbox key={day} value={day}>
+                        {day}
+                      </Checkbox>
                     ))}
                   </HStack>
                 </CheckboxGroup>
@@ -276,19 +282,34 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
                 <CheckboxGroup
                   colorScheme="green"
                   value={searchOptions.times}
-                  onChange={(values) => changeSearchOption('times', values.map(Number))}
+                  onChange={values => changeSearchOption('times', values.map(Number))}
                 >
                   <Wrap spacing={1} mb={2}>
-                    {searchOptions.times.sort((a, b) => a - b).map(time => (
-                      <Tag key={time} size="sm" variant="outline" colorScheme="blue">
-                        <TagLabel>{time}교시</TagLabel>
-                        <TagCloseButton
-                          onClick={() => changeSearchOption('times', searchOptions.times.filter(v => v !== time))}/>
-                      </Tag>
-                    ))}
+                    {searchOptions.times
+                      .sort((a, b) => a - b)
+                      .map(time => (
+                        <Tag key={time} size="sm" variant="outline" colorScheme="blue">
+                          <TagLabel>{time}교시</TagLabel>
+                          <TagCloseButton
+                            onClick={() =>
+                              changeSearchOption(
+                                'times',
+                                searchOptions.times.filter(v => v !== time)
+                              )
+                            }
+                          />
+                        </Tag>
+                      ))}
                   </Wrap>
-                  <Stack spacing={2} overflowY="auto" h="100px" border="1px solid" borderColor="gray.200"
-                         borderRadius={5} p={2}>
+                  <Stack
+                    spacing={2}
+                    overflowY="auto"
+                    h="100px"
+                    border="1px solid"
+                    borderColor="gray.200"
+                    borderRadius={5}
+                    p={2}
+                  >
                     {TIME_SLOTS.map(({ id, label }) => (
                       <Box key={id}>
                         <Checkbox key={id} size="sm" value={id}>
@@ -305,19 +326,32 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
                 <CheckboxGroup
                   colorScheme="green"
                   value={searchOptions.majors}
-                  onChange={(values) => changeSearchOption('majors', values as string[])}
+                  onChange={values => changeSearchOption('majors', values as string[])}
                 >
                   <Wrap spacing={1} mb={2}>
                     {searchOptions.majors.map(major => (
                       <Tag key={major} size="sm" variant="outline" colorScheme="blue">
-                        <TagLabel>{major.split("<p>").pop()}</TagLabel>
+                        <TagLabel>{major.split('<p>').pop()}</TagLabel>
                         <TagCloseButton
-                          onClick={() => changeSearchOption('majors', searchOptions.majors.filter(v => v !== major))}/>
+                          onClick={() =>
+                            changeSearchOption(
+                              'majors',
+                              searchOptions.majors.filter(v => v !== major)
+                            )
+                          }
+                        />
                       </Tag>
                     ))}
                   </Wrap>
-                  <Stack spacing={2} overflowY="auto" h="100px" border="1px solid" borderColor="gray.200"
-                         borderRadius={5} p={2}>
+                  <Stack
+                    spacing={2}
+                    overflowY="auto"
+                    h="100px"
+                    border="1px solid"
+                    borderColor="gray.200"
+                    borderRadius={5}
+                    p={2}
+                  >
                     {allMajors.map(major => (
                       <Box key={major}>
                         <Checkbox key={major} size="sm" value={major}>
@@ -329,9 +363,7 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
                 </CheckboxGroup>
               </FormControl>
             </HStack>
-            <Text align="right">
-              검색결과: {filteredLectures.length}개
-            </Text>
+            <Text align="right">검색결과: {filteredLectures.length}개</Text>
             <Box>
               <Table>
                 <Thead>
@@ -356,16 +388,22 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
                         <Td width="50px">{lecture.grade}</Td>
                         <Td width="200px">{lecture.title}</Td>
                         <Td width="50px">{lecture.credits}</Td>
-                        <Td width="150px" dangerouslySetInnerHTML={{ __html: lecture.major }}/>
-                        <Td width="150px" dangerouslySetInnerHTML={{ __html: lecture.schedule }}/>
+                        <Td width="150px" dangerouslySetInnerHTML={{ __html: lecture.major }} />
+                        <Td width="150px" dangerouslySetInnerHTML={{ __html: lecture.schedule }} />
                         <Td width="80px">
-                          <Button size="sm" colorScheme="green" onClick={() => addSchedule(lecture)}>추가</Button>
+                          <Button
+                            size="sm"
+                            colorScheme="green"
+                            onClick={() => addSchedule(lecture)}
+                          >
+                            추가
+                          </Button>
                         </Td>
                       </Tr>
                     ))}
                   </Tbody>
                 </Table>
-                <Box ref={loaderRef} h="20px"/>
+                <Box ref={loaderRef} h="20px" />
               </Box>
             </Box>
           </VStack>

--- a/src/SearchDialog.tsx
+++ b/src/SearchDialog.tsx
@@ -29,8 +29,7 @@ import {
   VStack,
   Wrap,
 } from '@chakra-ui/react';
-import { useScheduleContext } from './ScheduleContext.tsx';
-import { Lecture } from './types.ts';
+import { Lecture, Schedule } from './types.ts';
 import { parseSchedule } from './utils.ts';
 import axios from 'axios';
 import { DAY_LABELS } from './constants.ts';
@@ -42,6 +41,7 @@ interface Props {
     time?: number;
   } | null;
   onClose: () => void;
+  onScheduleAdd: (schedules: Schedule[]) => void;
 }
 
 interface SearchOption {
@@ -97,9 +97,7 @@ const fetchAllLectures = async () =>
   ]);
 
 // TODO: 이 컴포넌트에서 불필요한 연산이 발생하지 않도록 다양한 방식으로 시도해주세요.
-const SearchDialog = ({ searchInfo, onClose }: Props) => {
-  const { setSchedulesMap } = useScheduleContext();
-
+const SearchDialog = ({ searchInfo, onClose, onScheduleAdd }: Props) => {
   const loaderWrapperRef = useRef<HTMLDivElement>(null);
   const loaderRef = useRef<HTMLDivElement>(null);
   const [lectures, setLectures] = useState<Lecture[]>([]);
@@ -153,18 +151,12 @@ const SearchDialog = ({ searchInfo, onClose }: Props) => {
   const addSchedule = (lecture: Lecture) => {
     if (!searchInfo) return;
 
-    const { tableId } = searchInfo;
-
     const schedules = parseSchedule(lecture.schedule).map(schedule => ({
       ...schedule,
       lecture,
     }));
 
-    setSchedulesMap(prev => ({
-      ...prev,
-      [tableId]: [...prev[tableId], ...schedules],
-    }));
-
+    onScheduleAdd(schedules);
     onClose();
   };
 

--- a/src/TableWrapper.tsx
+++ b/src/TableWrapper.tsx
@@ -1,0 +1,85 @@
+import { Button, ButtonGroup, Flex, Heading, Stack } from '@chakra-ui/react';
+import { useState, useCallback } from 'react';
+import ScheduleTable from './ScheduleTable.tsx';
+import SearchDialog from './SearchDialog.tsx';
+import ScheduleDndProvider from './ScheduleDndProvider.tsx';
+import { useScheduleContext } from './ScheduleContext.tsx';
+import { Schedule } from './types.ts';
+
+interface TableWrapperProps {
+  tableId: string;
+  index: number;
+}
+
+const TableWrapper = ({ tableId, index }: TableWrapperProps) => {
+  const { initialSchedulesMap, duplicateTable, removeTable, tableIds } = useScheduleContext();
+
+  const [schedules, setSchedules] = useState<Schedule[]>(initialSchedulesMap[tableId] || []);
+  const [searchInfo, setSearchInfo] = useState<{
+    day?: string;
+    time?: number;
+  } | null>(null);
+
+  const disabledRemoveButton = tableIds.length === 1;
+
+  const handleDeleteSchedule = useCallback(({ day, time }: { day: string; time: number }) => {
+    setSchedules(prev =>
+      prev.filter(schedule => schedule.day !== day || !schedule.range.includes(time))
+    );
+  }, []);
+
+  const handleScheduleTimeClick = useCallback((timeInfo: { day?: string; time?: number }) => {
+    setSearchInfo(timeInfo);
+  }, []);
+
+  const handleDuplicate = useCallback(() => {
+    duplicateTable(tableId, schedules); // 현재 상태를 복제
+  }, [tableId, schedules, duplicateTable]);
+
+  const handleRemove = useCallback(() => {
+    removeTable(tableId);
+  }, [tableId, removeTable]);
+
+  const handleScheduleAdd = useCallback((newSchedules: Schedule[]) => {
+    setSchedules(prev => [...prev, ...newSchedules]);
+    setSearchInfo(null);
+  }, []);
+
+  return (
+    <Stack width="600px">
+      <Flex justifyContent="space-between" alignItems="center">
+        <Heading as="h3" fontSize="lg">
+          시간표 {index + 1}
+        </Heading>
+        <ButtonGroup size="sm" isAttached>
+          <Button colorScheme="green" onClick={() => setSearchInfo({})}>
+            시간표 추가
+          </Button>
+          <Button colorScheme="green" mx="1px" onClick={handleDuplicate}>
+            복제
+          </Button>
+          <Button colorScheme="green" isDisabled={disabledRemoveButton} onClick={handleRemove}>
+            삭제
+          </Button>
+        </ButtonGroup>
+      </Flex>
+
+      <ScheduleDndProvider tableId={tableId} schedules={schedules} onSchedulesChange={setSchedules}>
+        <ScheduleTable
+          schedules={schedules}
+          tableId={tableId}
+          onScheduleTimeClick={handleScheduleTimeClick}
+          onDeleteButtonClick={handleDeleteSchedule}
+        />
+      </ScheduleDndProvider>
+
+      <SearchDialog
+        searchInfo={searchInfo ? { tableId, ...searchInfo } : null}
+        onClose={() => setSearchInfo(null)}
+        onScheduleAdd={handleScheduleAdd}
+      />
+    </Stack>
+  );
+};
+
+export default TableWrapper;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const DAY_LABELS = ["월", "화", "수", "목", "금", "토"] as const;
+export const DAY_LABELS = ['월', '화', '수', '목', '금', '토'] as const;
 
 export const CellSize = {
   WIDTH: 80,

--- a/src/dummyScheduleMap.ts
+++ b/src/dummyScheduleMap.ts
@@ -1,746 +1,495 @@
 export default {
-  "schedule-1": [
+  'schedule-1': [
     {
-      "day": "월",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "2공521",
-      "lecture": {
-        "id": "529540",
-        "title": "SW융합코딩1",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "월1~6(2공521)",
-        "grade": 1
-      }
+      day: '월',
+      range: [1, 2, 3, 4, 5, 6],
+      room: '2공521',
+      lecture: {
+        id: '529540',
+        title: 'SW융합코딩1',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '월1~6(2공521)',
+        grade: 1,
+      },
     },
     {
-      "day": "화",
-      "range": [
-        1,
-        2,
-        3
-      ],
-      "room": "미디어509",
-      "lecture": {
-        "id": "527790",
-        "title": "객체지향프로그래밍(SW)",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "화1~3(미디어509)<p>목1~3(미디어509)",
-        "grade": 2
-      }
+      day: '화',
+      range: [1, 2, 3],
+      room: '미디어509',
+      lecture: {
+        id: '527790',
+        title: '객체지향프로그래밍(SW)',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '화1~3(미디어509)<p>목1~3(미디어509)',
+        grade: 2,
+      },
     },
     {
-      "day": "목",
-      "range": [
-        1,
-        2,
-        3
-      ],
-      "room": "미디어509",
-      "lecture": {
-        "id": "527790",
-        "title": "객체지향프로그래밍(SW)",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "화1~3(미디어509)<p>목1~3(미디어509)",
-        "grade": 2
-      }
+      day: '목',
+      range: [1, 2, 3],
+      room: '미디어509',
+      lecture: {
+        id: '527790',
+        title: '객체지향프로그래밍(SW)',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '화1~3(미디어509)<p>목1~3(미디어509)',
+        grade: 2,
+      },
     },
     {
-      "day": "수",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "소프트304",
-      "lecture": {
-        "id": "540970",
-        "title": "파이썬프로그래밍(SW융합)",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "수1~6(소프트304)",
-        "grade": 2
-      }
+      day: '수',
+      range: [1, 2, 3, 4, 5, 6],
+      room: '소프트304',
+      lecture: {
+        id: '540970',
+        title: '파이썬프로그래밍(SW융합)',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '수1~6(소프트304)',
+        grade: 2,
+      },
     },
     {
-      "day": "금",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "2공524",
-      "lecture": {
-        "id": "359210",
-        "title": "선형대수",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "금1~6(2공524)",
-        "grade": 2
-      }
+      day: '금',
+      range: [1, 2, 3, 4, 5, 6],
+      room: '2공524',
+      lecture: {
+        id: '359210',
+        title: '선형대수',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '금1~6(2공524)',
+        grade: 2,
+      },
     },
     {
-      "day": "목",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18
-      ],
-      "room": "소프트414",
-      "lecture": {
-        "id": "548310",
-        "title": "실무중심종합설계프로젝트(티맥스)",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "목1~18(소프트414)<p>토1~18(소프트414)",
-        "grade": 3
-      }
+      day: '목',
+      range: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+      room: '소프트414',
+      lecture: {
+        id: '548310',
+        title: '실무중심종합설계프로젝트(티맥스)',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '목1~18(소프트414)<p>토1~18(소프트414)',
+        grade: 3,
+      },
     },
     {
-      "day": "토",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        17,
-        18
-      ],
-      "room": "소프트414",
-      "lecture": {
-        "id": "548310",
-        "title": "실무중심종합설계프로젝트(티맥스)",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "목1~18(소프트414)<p>토1~18(소프트414)",
-        "grade": 3
-      }
-    }
+      day: '토',
+      range: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+      room: '소프트414',
+      lecture: {
+        id: '548310',
+        title: '실무중심종합설계프로젝트(티맥스)',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '목1~18(소프트414)<p>토1~18(소프트414)',
+        grade: 3,
+      },
+    },
   ],
-  "schedule-2": [
+  'schedule-2': [
     {
-      "day": "월",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "국제205_PC",
-      "lecture": {
-        "id": "525770",
-        "title": "자료구조기초및실습",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "월1~6(국제205_PC)",
-        "grade": 2
-      }
+      day: '월',
+      range: [1, 2, 3, 4, 5, 6],
+      room: '국제205_PC',
+      lecture: {
+        id: '525770',
+        title: '자료구조기초및실습',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '월1~6(국제205_PC)',
+        grade: 2,
+      },
     },
     {
-      "day": "화",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "소프트227",
-      "lecture": {
-        "id": "372460",
-        "title": "알고리즘",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "화1~6(소프트227)",
-        "grade": 3
-      }
+      day: '화',
+      range: [1, 2, 3, 4, 5, 6],
+      room: '소프트227',
+      lecture: {
+        id: '372460',
+        title: '알고리즘',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '화1~6(소프트227)',
+        grade: 3,
+      },
     },
     {
-      "day": "수",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      "room": "2공524",
-      "lecture": {
-        "id": "388600",
-        "title": "인공지능",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "수1~9(2공524)",
-        "grade": 3
-      }
+      day: '수',
+      range: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+      room: '2공524',
+      lecture: {
+        id: '388600',
+        title: '인공지능',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '수1~9(2공524)',
+        grade: 3,
+      },
     },
     {
-      "day": "목",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "소프트516",
-      "lecture": {
-        "id": "524820",
-        "title": "오픈소스SW활용",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "목1~6(소프트516)",
-        "grade": 3
-      }
+      day: '목',
+      range: [1, 2, 3, 4, 5, 6],
+      room: '소프트516',
+      lecture: {
+        id: '524820',
+        title: '오픈소스SW활용',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '목1~6(소프트516)',
+        grade: 3,
+      },
     },
     {
-      "day": "금",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11
-      ],
-      "room": "소프트414",
-      "lecture": {
-        "id": "548300",
-        "title": "인공지능입문및실습(티맥스)",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "금1~11(소프트414)",
-        "grade": 3
-      }
+      day: '금',
+      range: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      room: '소프트414',
+      lecture: {
+        id: '548300',
+        title: '인공지능입문및실습(티맥스)',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '금1~11(소프트414)',
+        grade: 3,
+      },
     },
     {
-      "day": "토",
-      "range": [
-        1,
-        2
-      ],
-      "room": "",
-      "lecture": {
-        "id": "451150",
-        "title": "노래-목소리3",
-        "credits": "1(0)",
-        "major": "음악·예술대학<p>공연영화학부 뮤지컬전공",
-        "schedule": "토1~2",
-        "grade": 3
-      }
-    }
+      day: '토',
+      range: [1, 2],
+      room: '',
+      lecture: {
+        id: '451150',
+        title: '노래-목소리3',
+        credits: '1(0)',
+        major: '음악·예술대학<p>공연영화학부 뮤지컬전공',
+        schedule: '토1~2',
+        grade: 3,
+      },
+    },
   ],
-  "schedule-3": [
+  'schedule-3': [
     {
-      "day": "월",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11
-      ],
-      "room": "소프트414",
-      "lecture": {
-        "id": "548290",
-        "title": "운영체제및실습(티맥스)",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "월1~11(소프트414)",
-        "grade": 4
-      }
+      day: '월',
+      range: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      room: '소프트414',
+      lecture: {
+        id: '548290',
+        title: '운영체제및실습(티맥스)',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '월1~11(소프트414)',
+        grade: 4,
+      },
     },
     {
-      "day": "화",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11
-      ],
-      "room": "소프트414",
-      "lecture": {
-        "id": "548280",
-        "title": "데이터베이스와SQL실습(티맥스)",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합경제경영전공",
-        "schedule": "화1~11(소프트414)",
-        "grade": 4
-      }
+      day: '화',
+      range: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      room: '소프트414',
+      lecture: {
+        id: '548280',
+        title: '데이터베이스와SQL실습(티맥스)',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합경제경영전공',
+        schedule: '화1~11(소프트414)',
+        grade: 4,
+      },
     },
     {
-      "day": "수",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "소프트406",
-      "lecture": {
-        "id": "366770",
-        "title": "시스템분석및설계",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>SW융합학부<p>SW융합바이오전공",
-        "schedule": "수1~6(소프트406)",
-        "grade": 4
-      }
+      day: '수',
+      range: [1, 2, 3, 4, 5, 6],
+      room: '소프트406',
+      lecture: {
+        id: '366770',
+        title: '시스템분석및설계',
+        credits: '3(0)',
+        major: 'SW융합대학<p>SW융합학부<p>SW융합바이오전공',
+        schedule: '수1~6(소프트406)',
+        grade: 4,
+      },
     },
     {
-      "day": "목",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "미디어403",
-      "lecture": {
-        "id": "539800",
-        "title": "캡스톤디자인(정보통계)",
-        "credits": "3(0)",
-        "major": "SW융합대학<p>정보통계학과",
-        "schedule": "목1~6(미디어403)",
-        "grade": 4
-      }
+      day: '목',
+      range: [1, 2, 3, 4, 5, 6],
+      room: '미디어403',
+      lecture: {
+        id: '539800',
+        title: '캡스톤디자인(정보통계)',
+        credits: '3(0)',
+        major: 'SW융합대학<p>정보통계학과',
+        schedule: '목1~6(미디어403)',
+        grade: 4,
+      },
     },
     {
-      "day": "금",
-      "range": [
-        1,
-        2
-      ],
-      "room": "치114",
-      "lecture": {
-        "id": "394090",
-        "title": "임상보철학2",
-        "credits": "1(0)",
-        "major": "치과대학<p>치의학과",
-        "schedule": "금1~2(치114)",
-        "grade": 4
-      }
+      day: '금',
+      range: [1, 2],
+      room: '치114',
+      lecture: {
+        id: '394090',
+        title: '임상보철학2',
+        credits: '1(0)',
+        major: '치과대학<p>치의학과',
+        schedule: '금1~2(치114)',
+        grade: 4,
+      },
     },
     {
-      "day": "토",
-      "range": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "",
-      "lecture": {
-        "id": "550040",
-        "title": "반도체기초공학및산업의이해",
-        "credits": "3(0)",
-        "major": "공과대학<p>반도체WAVE융합전공",
-        "schedule": "토1~6",
-        "grade": 4
-      }
-    }
+      day: '토',
+      range: [1, 2, 3, 4, 5, 6],
+      room: '',
+      lecture: {
+        id: '550040',
+        title: '반도체기초공학및산업의이해',
+        credits: '3(0)',
+        major: '공과대학<p>반도체WAVE융합전공',
+        schedule: '토1~6',
+        grade: 4,
+      },
+    },
   ],
-  "schedule-4": [
+  'schedule-4': [
     {
-      "day": "월",
-      "range": [
-        11,
-        12,
-        13,
-        14,
-        15,
-        16
-      ],
-      "room": "예323",
-      "lecture": {
-        "id": "343070",
-        "title": "문학사세미나",
-        "credits": "3(0)",
-        "major": "예술대학<p>문예창작과",
-        "schedule": "월11~16(예323)",
-        "grade": 1
-      }
+      day: '월',
+      range: [11, 12, 13, 14, 15, 16],
+      room: '예323',
+      lecture: {
+        id: '343070',
+        title: '문학사세미나',
+        credits: '3(0)',
+        major: '예술대학<p>문예창작과',
+        schedule: '월11~16(예323)',
+        grade: 1,
+      },
     },
     {
-      "day": "화",
-      "range": [
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      "room": "예018",
-      "lecture": {
-        "id": "361960",
-        "title": "소설창작세미나1",
-        "credits": "3(0)",
-        "major": "예술대학<p>문예창작과",
-        "schedule": "화3~8(예018)",
-        "grade": 3
-      }
+      day: '화',
+      range: [3, 4, 5, 6, 7, 8],
+      room: '예018',
+      lecture: {
+        id: '361960',
+        title: '소설창작세미나1',
+        credits: '3(0)',
+        major: '예술대학<p>문예창작과',
+        schedule: '화3~8(예018)',
+        grade: 3,
+      },
     },
     {
-      "day": "수",
-      "range": [
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      "room": "예술관D동207",
-      "lecture": {
-        "id": "533510",
-        "title": "영상문학의이론과창작",
-        "credits": "3(0)",
-        "major": "예술대학<p>문예창작과",
-        "schedule": "수3~8(예술관D동207)",
-        "grade": 2
-      }
+      day: '수',
+      range: [3, 4, 5, 6, 7, 8],
+      room: '예술관D동207',
+      lecture: {
+        id: '533510',
+        title: '영상문학의이론과창작',
+        credits: '3(0)',
+        major: '예술대학<p>문예창작과',
+        schedule: '수3~8(예술관D동207)',
+        grade: 2,
+      },
     },
     {
-      "day": "목",
-      "range": [
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      "room": "예술관D동308",
-      "lecture": {
-        "id": "533520",
-        "title": "비평창작연습",
-        "credits": "3(0)",
-        "major": "예술대학<p>문예창작과",
-        "schedule": "목3~8(예술관D동308)",
-        "grade": 3
-      }
+      day: '목',
+      range: [3, 4, 5, 6, 7, 8],
+      room: '예술관D동308',
+      lecture: {
+        id: '533520',
+        title: '비평창작연습',
+        credits: '3(0)',
+        major: '예술대학<p>문예창작과',
+        schedule: '목3~8(예술관D동308)',
+        grade: 3,
+      },
     },
     {
-      "day": "금",
-      "range": [
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      "room": "예술관D동308",
-      "lecture": {
-        "id": "481130",
-        "title": "소설창작연습",
-        "credits": "3(0)",
-        "major": "예술대학<p>문예창작과",
-        "schedule": "금3~8(예술관D동308)",
-        "grade": 2
-      }
-    }
+      day: '금',
+      range: [3, 4, 5, 6, 7, 8],
+      room: '예술관D동308',
+      lecture: {
+        id: '481130',
+        title: '소설창작연습',
+        credits: '3(0)',
+        major: '예술대학<p>문예창작과',
+        schedule: '금3~8(예술관D동308)',
+        grade: 2,
+      },
+    },
   ],
-  "schedule-5": [
+  'schedule-5': [
     {
-      "day": "월",
-      "range": [
-        3,
-        4,
-        5,
-        6
-      ],
-      "room": "의228",
-      "lecture": {
-        "id": "432030",
-        "title": "해부학",
-        "credits": "2(0)",
-        "major": "간호대학<p>간호학과",
-        "schedule": "월3~6(의228)",
-        "grade": 1
-      }
+      day: '월',
+      range: [3, 4, 5, 6],
+      room: '의228',
+      lecture: {
+        id: '432030',
+        title: '해부학',
+        credits: '2(0)',
+        major: '간호대학<p>간호학과',
+        schedule: '월3~6(의228)',
+        grade: 1,
+      },
     },
     {
-      "day": "화",
-      "range": [
-        1,
-        2,
-        3
-      ],
-      "room": "의228",
-      "lecture": {
-        "id": "323070",
-        "title": "기본간호학1",
-        "credits": "3(0)",
-        "major": "간호대학<p>간호학과",
-        "schedule": "화1~3(의228)<p>목10~12(의228)",
-        "grade": 2
-      }
+      day: '화',
+      range: [1, 2, 3],
+      room: '의228',
+      lecture: {
+        id: '323070',
+        title: '기본간호학1',
+        credits: '3(0)',
+        major: '간호대학<p>간호학과',
+        schedule: '화1~3(의228)<p>목10~12(의228)',
+        grade: 2,
+      },
     },
     {
-      "day": "목",
-      "range": [
-        7,
-        8,
-        9
-      ],
-      "room": "의228",
-      "lecture": {
-        "id": "323070",
-        "title": "기본간호학1",
-        "credits": "3(0)",
-        "major": "간호대학<p>간호학과",
-        "schedule": "화1~3(의228)<p>목10~12(의228)",
-        "grade": 2
-      }
+      day: '목',
+      range: [7, 8, 9],
+      room: '의228',
+      lecture: {
+        id: '323070',
+        title: '기본간호학1',
+        credits: '3(0)',
+        major: '간호대학<p>간호학과',
+        schedule: '화1~3(의228)<p>목10~12(의228)',
+        grade: 2,
+      },
     },
     {
-      "day": "수",
-      "range": [
-        1,
-        2,
-        3,
-        4
-      ],
-      "room": "의230",
-      "lecture": {
-        "id": "411690",
-        "title": "지역사회간호학3",
-        "credits": "2(0)",
-        "major": "간호대학<p>간호학과",
-        "schedule": "수1~4(의230)",
-        "grade": 4
-      }
+      day: '수',
+      range: [1, 2, 3, 4],
+      room: '의230',
+      lecture: {
+        id: '411690',
+        title: '지역사회간호학3',
+        credits: '2(0)',
+        major: '간호대학<p>간호학과',
+        schedule: '수1~4(의230)',
+        grade: 4,
+      },
     },
     {
-      "day": "금",
-      "range": [
-        1,
-        2,
-        3
-      ],
-      "room": "인521",
-      "lecture": {
-        "id": "409440",
-        "title": "중급일본어강독1",
-        "credits": "3(0)",
-        "major": "외국어대학<p>아시아중동학부 일본학전공",
-        "schedule": "화15~17(인521)<p>목8~10(인424)",
-        "grade": 2
-      }
+      day: '금',
+      range: [1, 2, 3],
+      room: '인521',
+      lecture: {
+        id: '409440',
+        title: '중급일본어강독1',
+        credits: '3(0)',
+        major: '외국어대학<p>아시아중동학부 일본학전공',
+        schedule: '화15~17(인521)<p>목8~10(인424)',
+        grade: 2,
+      },
     },
     {
-      "day": "목",
-      "range": [
-        1,
-        2,
-        3
-      ],
-      "room": "인424",
-      "lecture": {
-        "id": "409440",
-        "title": "중급일본어강독1",
-        "credits": "3(0)",
-        "major": "외국어대학<p>아시아중동학부 일본학전공",
-        "schedule": "화15~17(인521)<p>목8~10(인424)",
-        "grade": 2
-      }
-    }
+      day: '목',
+      range: [1, 2, 3],
+      room: '인424',
+      lecture: {
+        id: '409440',
+        title: '중급일본어강독1',
+        credits: '3(0)',
+        major: '외국어대학<p>아시아중동학부 일본학전공',
+        schedule: '화15~17(인521)<p>목8~10(인424)',
+        grade: 2,
+      },
+    },
   ],
-  "schedule-6": [
+  'schedule-6': [
     {
-      "day": "화",
-      "range": [
-        9,
-        10
-      ],
-      "room": "음악133",
-      "lecture": {
-        "id": "471870",
-        "title": "연주A",
-        "credits": "1(0)",
-        "major": "음악·예술대학<p>음악학부 기악전공(피아노)",
-        "schedule": "화9~10(음악133)",
-        "grade": 1
-      }
+      day: '화',
+      range: [9, 10],
+      room: '음악133',
+      lecture: {
+        id: '471870',
+        title: '연주A',
+        credits: '1(0)',
+        major: '음악·예술대학<p>음악학부 기악전공(피아노)',
+        schedule: '화9~10(음악133)',
+        grade: 1,
+      },
     },
     {
-      "day": "토",
-      "range": [
-        3,
-        4
-      ],
-      "room": "",
-      "lecture": {
-        "id": "502420",
-        "title": "피아노실기A",
-        "credits": "1(0)",
-        "major": "음악·예술대학<p>음악학부 기악전공(피아노)",
-        "schedule": "토3~4",
-        "grade": 1
-      }
+      day: '토',
+      range: [3, 4],
+      room: '',
+      lecture: {
+        id: '502420',
+        title: '피아노실기A',
+        credits: '1(0)',
+        major: '음악·예술대학<p>음악학부 기악전공(피아노)',
+        schedule: '토3~4',
+        grade: 1,
+      },
     },
     {
-      "day": "토",
-      "range": [
-        7,
-        8
-      ],
-      "room": "",
-      "lecture": {
-        "id": "502420",
-        "title": "피아노실기A",
-        "credits": "1(0)",
-        "major": "음악·예술대학<p>음악학부 기악전공(피아노)",
-        "schedule": "토7~8",
-        "grade": 1
-      }
+      day: '토',
+      range: [7, 8],
+      room: '',
+      lecture: {
+        id: '502420',
+        title: '피아노실기A',
+        credits: '1(0)',
+        major: '음악·예술대학<p>음악학부 기악전공(피아노)',
+        schedule: '토7~8',
+        grade: 1,
+      },
     },
     {
-      "day": "월",
-      "range": [
-        13,
-        14,
-        15,
-        16
-      ],
-      "room": "음악104",
-      "lecture": {
-        "id": "318720",
-        "title": "국악사1",
-        "credits": "2(0)",
-        "major": "음악·예술대학<p>음악학부 기악전공",
-        "schedule": "월13~16(음악104)",
-        "grade": 2
-      }
+      day: '월',
+      range: [13, 14, 15, 16],
+      room: '음악104',
+      lecture: {
+        id: '318720',
+        title: '국악사1',
+        credits: '2(0)',
+        major: '음악·예술대학<p>음악학부 기악전공',
+        schedule: '월13~16(음악104)',
+        grade: 2,
+      },
     },
     {
-      "day": "목",
-      "range": [
-        9,
-        10,
-        11,
-        12
-      ],
-      "room": "음악106",
-      "lecture": {
-        "id": "358200",
-        "title": "서양음악사1",
-        "credits": "2(0)",
-        "major": "음악·예술대학<p>음악학부 기악전공",
-        "schedule": "목9~12(음악106)",
-        "grade": 2
-      }
+      day: '목',
+      range: [9, 10, 11, 12],
+      room: '음악106',
+      lecture: {
+        id: '358200',
+        title: '서양음악사1',
+        credits: '2(0)',
+        major: '음악·예술대학<p>음악학부 기악전공',
+        schedule: '목9~12(음악106)',
+        grade: 2,
+      },
     },
     {
-      "day": "화",
-      "range": [
-        1,
-        2,
-        3,
-        4
-      ],
-      "room": "음악105",
-      "lecture": {
-        "id": "367110",
-        "title": "시창청음",
-        "credits": "2(0)",
-        "major": "음악·예술대학<p>음악학부 기악전공",
-        "schedule": "화5~8(음악105)",
-        "grade": 1
-      }
+      day: '화',
+      range: [1, 2, 3, 4],
+      room: '음악105',
+      lecture: {
+        id: '367110',
+        title: '시창청음',
+        credits: '2(0)',
+        major: '음악·예술대학<p>음악학부 기악전공',
+        schedule: '화5~8(음악105)',
+        grade: 1,
+      },
     },
     {
-      "day": "금",
-      "range": [
-        5,
-        6,
-        7,
-        8
-      ],
-      "room": "음악105",
-      "lecture": {
-        "id": "358200",
-        "title": "서양음악사1",
-        "credits": "2(0)",
-        "major": "음악·예술대학<p>음악학부 기악전공",
-        "schedule": "금5~8(음악105)",
-        "grade": 2
-      }
-    }
-  ]
-}
+      day: '금',
+      range: [5, 6, 7, 8],
+      room: '음악105',
+      lecture: {
+        id: '358200',
+        title: '서양음악사1',
+        credits: '2(0)',
+        major: '음악·예술대학<p>음악학부 기악전공',
+        schedule: '금5~8(음악105)',
+        grade: 2,
+      },
+    },
+  ],
+};

--- a/src/form/FormCredits.tsx
+++ b/src/form/FormCredits.tsx
@@ -1,0 +1,27 @@
+import { FormControl, FormLabel, Select } from '@chakra-ui/react';
+import { SearchOption } from '../SearchDialog';
+import React from 'react';
+
+const FormCredits = React.memo(
+  ({
+    credits,
+    changeSearchOption,
+  }: {
+    credits?: number;
+    changeSearchOption: (field: keyof SearchOption, value: SearchOption[typeof field]) => void;
+  }) => {
+    return (
+      <FormControl>
+        <FormLabel>학점</FormLabel>
+        <Select value={credits} onChange={e => changeSearchOption('credits', e.target.value)}>
+          <option value="">전체</option>
+          <option value="1">1학점</option>
+          <option value="2">2학점</option>
+          <option value="3">3학점</option>
+        </Select>
+      </FormControl>
+    );
+  }
+);
+
+export default FormCredits;

--- a/src/form/FormDays.tsx
+++ b/src/form/FormDays.tsx
@@ -1,0 +1,35 @@
+import { FormControl, FormLabel, CheckboxGroup, HStack, Checkbox } from '@chakra-ui/react';
+import { SearchOption } from '../SearchDialog';
+import React from 'react';
+
+const DAY_LABELS = ['월', '화', '수', '목', '금', '토'];
+
+const FormDays = React.memo(
+  ({
+    days,
+    changeSearchOption,
+  }: {
+    days: string[];
+    changeSearchOption: (field: keyof SearchOption, value: SearchOption[typeof field]) => void;
+  }) => {
+    return (
+      <FormControl>
+        <FormLabel>요일</FormLabel>
+        <CheckboxGroup
+          value={days}
+          onChange={value => changeSearchOption('days', value as string[])}
+        >
+          <HStack spacing={4}>
+            {DAY_LABELS.map(day => (
+              <Checkbox key={day} value={day}>
+                {day}
+              </Checkbox>
+            ))}
+          </HStack>
+        </CheckboxGroup>
+      </FormControl>
+    );
+  }
+);
+
+export default FormDays;

--- a/src/form/FormGrades.tsx
+++ b/src/form/FormGrades.tsx
@@ -1,0 +1,35 @@
+import { FormControl, FormLabel, CheckboxGroup, HStack, Checkbox } from '@chakra-ui/react';
+import { SearchOption } from '../SearchDialog';
+import React from 'react';
+
+const GRADE_OPTIONS = [1, 2, 3, 4];
+
+const FormGrades = React.memo(
+  ({
+    grades,
+    changeSearchOption,
+  }: {
+    grades: number[];
+    changeSearchOption: (field: keyof SearchOption, value: SearchOption[typeof field]) => void;
+  }) => {
+    return (
+      <FormControl>
+        <FormLabel>학년</FormLabel>
+        <CheckboxGroup
+          value={grades}
+          onChange={value => changeSearchOption('grades', value.map(Number))}
+        >
+          <HStack spacing={4}>
+            {GRADE_OPTIONS.map(grade => (
+              <Checkbox key={grade} value={grade}>
+                {grade}학년
+              </Checkbox>
+            ))}
+          </HStack>
+        </CheckboxGroup>
+      </FormControl>
+    );
+  }
+);
+
+export default FormGrades;

--- a/src/form/FormMajors.tsx
+++ b/src/form/FormMajors.tsx
@@ -1,0 +1,72 @@
+import {
+  FormControl,
+  FormLabel,
+  CheckboxGroup,
+  Wrap,
+  Tag,
+  TagLabel,
+  TagCloseButton,
+  Stack,
+  Box,
+  Checkbox,
+} from '@chakra-ui/react';
+import { SearchOption } from '../SearchDialog';
+import React from 'react';
+
+const FormMajors = React.memo(
+  ({
+    majors,
+    allMajors,
+    changeSearchOption,
+  }: {
+    majors: string[];
+    allMajors: string[];
+    changeSearchOption: (field: keyof SearchOption, value: SearchOption[typeof field]) => void;
+  }) => {
+    return (
+      <FormControl>
+        <FormLabel>전공</FormLabel>
+        <CheckboxGroup
+          colorScheme="green"
+          value={majors}
+          onChange={values => changeSearchOption('majors', values as string[])}
+        >
+          <Wrap spacing={1} mb={2}>
+            {majors.map(major => (
+              <Tag key={major} size="sm" variant="outline" colorScheme="blue">
+                <TagLabel>{major.split('<p>').pop()}</TagLabel>
+                <TagCloseButton
+                  onClick={() =>
+                    changeSearchOption(
+                      'majors',
+                      majors.filter(v => v !== major)
+                    )
+                  }
+                />
+              </Tag>
+            ))}
+          </Wrap>
+          <Stack
+            spacing={2}
+            overflowY="auto"
+            h="100px"
+            border="1px solid"
+            borderColor="gray.200"
+            borderRadius={5}
+            p={2}
+          >
+            {allMajors.map(major => (
+              <Box key={major}>
+                <Checkbox key={major} size="sm" value={major}>
+                  {major.replace(/<p>/gi, ' ')}
+                </Checkbox>
+              </Box>
+            ))}
+          </Stack>
+        </CheckboxGroup>
+      </FormControl>
+    );
+  }
+);
+
+export default FormMajors;

--- a/src/form/FormSearch.tsx
+++ b/src/form/FormSearch.tsx
@@ -1,0 +1,30 @@
+import { FormControl, FormLabel, Input } from '@chakra-ui/react';
+import { SearchOption } from '../SearchDialog';
+import React from 'react';
+
+const FormSearch = React.memo(
+  ({
+    query,
+    changeSearchOption,
+    formLabel,
+    placeholder,
+  }: {
+    query?: string;
+    changeSearchOption: (field: keyof SearchOption, value: SearchOption[typeof field]) => void;
+    formLabel: string;
+    placeholder: string;
+  }) => {
+    return (
+      <FormControl>
+        <FormLabel>{formLabel}</FormLabel>
+        <Input
+          placeholder={placeholder}
+          value={query}
+          onChange={e => changeSearchOption('query', e.target.value)}
+        />
+      </FormControl>
+    );
+  }
+);
+
+export default FormSearch;

--- a/src/form/FormTimes.tsx
+++ b/src/form/FormTimes.tsx
@@ -1,0 +1,99 @@
+import {
+  FormControl,
+  FormLabel,
+  CheckboxGroup,
+  Wrap,
+  Tag,
+  TagLabel,
+  TagCloseButton,
+  Stack,
+  Box,
+  Checkbox,
+} from '@chakra-ui/react';
+import { SearchOption } from '../SearchDialog';
+import React from 'react';
+
+const TIME_SLOTS = [
+  { id: 1, label: '09:00~09:30' },
+  { id: 2, label: '09:30~10:00' },
+  { id: 3, label: '10:00~10:30' },
+  { id: 4, label: '10:30~11:00' },
+  { id: 5, label: '11:00~11:30' },
+  { id: 6, label: '11:30~12:00' },
+  { id: 7, label: '12:00~12:30' },
+  { id: 8, label: '12:30~13:00' },
+  { id: 9, label: '13:00~13:30' },
+  { id: 10, label: '13:30~14:00' },
+  { id: 11, label: '14:00~14:30' },
+  { id: 12, label: '14:30~15:00' },
+  { id: 13, label: '15:00~15:30' },
+  { id: 14, label: '15:30~16:00' },
+  { id: 15, label: '16:00~16:30' },
+  { id: 16, label: '16:30~17:00' },
+  { id: 17, label: '17:00~17:30' },
+  { id: 18, label: '17:30~18:00' },
+  { id: 19, label: '18:00~18:50' },
+  { id: 20, label: '18:55~19:45' },
+  { id: 21, label: '19:50~20:40' },
+  { id: 22, label: '20:45~21:35' },
+  { id: 23, label: '21:40~22:30' },
+  { id: 24, label: '22:35~23:25' },
+];
+
+const FormTimes = React.memo(
+  ({
+    times,
+    changeSearchOption,
+  }: {
+    times: number[];
+    changeSearchOption: (field: keyof SearchOption, value: SearchOption[typeof field]) => void;
+  }) => {
+    return (
+      <FormControl>
+        <FormLabel>시간</FormLabel>
+        <CheckboxGroup
+          colorScheme="green"
+          value={times}
+          onChange={values => changeSearchOption('times', values.map(Number))}
+        >
+          <Wrap spacing={1} mb={2}>
+            {times
+              .sort((a, b) => a - b)
+              .map(time => (
+                <Tag key={time} size="sm" variant="outline" colorScheme="blue">
+                  <TagLabel>{time}교시</TagLabel>
+                  <TagCloseButton
+                    onClick={() =>
+                      changeSearchOption(
+                        'times',
+                        times.filter(v => v !== time)
+                      )
+                    }
+                  />
+                </Tag>
+              ))}
+          </Wrap>
+          <Stack
+            spacing={2}
+            overflowY="auto"
+            h="100px"
+            border="1px solid"
+            borderColor="gray.200"
+            borderRadius={5}
+            p={2}
+          >
+            {TIME_SLOTS.map(({ id, label }) => (
+              <Box key={id}>
+                <Checkbox key={id} size="sm" value={id}>
+                  {id}교시({label})
+                </Checkbox>
+              </Box>
+            ))}
+          </Stack>
+        </CheckboxGroup>
+      </FormControl>
+    );
+  }
+);
+
+export default FormTimes;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
-import App from "./App.tsx";
-import { ChakraProvider } from "@chakra-ui/react";
-import { createRoot } from "react-dom/client";
+import App from './App.tsx';
+import { ChakraProvider } from '@chakra-ui/react';
+import { createRoot } from 'react-dom/client';
 
-createRoot(document.getElementById("root")!).render(
+createRoot(document.getElementById('root')!).render(
   <ChakraProvider>
-    <App/>
+    <App />
   </ChakraProvider>
-)
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,8 +8,8 @@ export interface Lecture {
 }
 
 export interface Schedule {
-  lecture: Lecture
+  lecture: Lecture;
   day: string;
-  range: number[]
+  range: number[];
   room?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,24 +6,23 @@ export const parseHnM = (current: number) => {
 };
 
 const getTimeRange = (value: string): number[] => {
-  const [start, end] = value.split("~").map(Number);
+  const [start, end] = value.split('~').map(Number);
   if (end === undefined) return [start];
   return Array(end - start + 1)
     .fill(start)
     .map((v, k) => v + k);
-}
+};
 
 export const parseSchedule = (schedule: string) => {
   const schedules = schedule.split('<p>');
   return schedules.map(schedule => {
-
     const reg = /^([가-힣])(\d+(~\d+)?)(.*)/;
 
     const [day] = schedule.split(/(\d+)/);
 
-    const range = getTimeRange(schedule.replace(reg, "$2"));
+    const range = getTimeRange(schedule.replace(reg, '$2'));
 
-    const room = schedule.replace(reg, "$4")?.replace(/\(|\)/g, "");
+    const room = schedule.replace(reg, '$4')?.replace(/\(|\)/g, '');
 
     return { day, range, room };
   });


### PR DESCRIPTION
# 과제 체크포인트

https://legitgoons.github.io/front_6th_chapter4-2
## 과제 요구사항

- [x] 배포 후 url 제출

- [x] API 호출 최적화(`Promise.all` 이해)

- [x] SearchDialog 불필요한 연산 최적화
- [x] SearchDialog 불필요한 리렌더링 최적화

- [x] 시간표 블록 드래그시 렌더링 최적화
- [x] 시간표 블록 드롭시 렌더링 최적화

## 과제 셀프회고

### 기술적 성장

#### 1. 캐시를 구현해보기
- 캐시로 api 호출 최적화하기
```typescript
const createCachedFetch = () => {
  const cache = new Map<string, Promise<AxiosResponse<Lecture[]>>>();

  const fetchMajors = () => {
    if (!cache.has('majors')) { // 캐시가 없다면 새로 axios 요청 호출 후 저장
      cache.set('majors', axios.get<Lecture[]>('./schedules-majors.json'));
    }
    return cache.get('majors')!; // 동일한 Promise 객체 반환
  };
 //...
```
```typescript
// 6번 호출하지만 실제로는 2번의 네트워크 요청만 발생
const fetchAllLectures = async () =>
  await Promise.all([
    fetchMajors(),     // 새로운 요청
    fetchLiberalArts(), // 새로운 요청
    fetchMajors(),     // 캐시에서 반환
    fetchLiberalArts(), // 캐시에서 반환
    fetchMajors(),     // 캐시에서 반환
    fetchLiberalArts()  // 캐시에서 반환
  ]);
```
#### 2. props에는 가능한 원시값을 넘겨주기
컴포넌트는 랜더링 될 때 마다 내부에서 새로운 선언이 이뤄진다.
근데 리액트는 Object.is()를 사용해서 원시값은 값만 비교하는데, 객체는 참조를 비교한다

고로 부모에서 매번 리랜더링이 일어나는 상태에서 참조값을 자식 컴포넌트에 props로 넘겨주면? 
memo해봤자 props가 계속 바뀌니까 자식 컴포넌트도 계속 리랜더링된다!

그렇기에, props에는 가능한 원시값을 넘겨주는 것이 권장된다.

#### 3. 메모이제이션을 적절하게 잘 사용하는 방법
그럼에도 불구하고 참조값을 props로 넘기고 싶다면 두 가지 방법이 있다.
1. **일단 받은 다음 react.memo의 propsAreEqual 함수 활용**
- react.memo의 propsAreEqual 함수 활용 예시
```typescript
// LectureTableRow.tsx
const LectureTableRow = React.memo<LectureTableRowProps>(
  ({ lecture, index, onAddSchedule }) => {
    return (
      <Tr key={`${lecture.id}-${index}`}>
 //...
      </Tr>
    );
  },

  // 커스텀 비교 함수: 각 필드를 하나씩 개별적으로 비교, 값이 true면 그대로 유지하고, false일 때에만 리렌더링 진행
  (prevProps, nextProps) => {
    return (
      prevProps.lecture.id === nextProps.lecture.id &&
      prevProps.lecture.grade === nextProps.lecture.grade &&
    //...
    );
  }
);
```

2. **useCallback으로 메모이제이션 한 후 props로 넘겨주기**
- useCallback의 경우, 컴포넌트가 리랜더링 되는 경우에도 의존값만 바뀌지 않으면 매번 재생성되는 것을 막을 수 있기에 props로 넘겨줘도 안전하다. 

> [!Note]
> 메모이제이션 기법 중 나머지 하나인 useMemo의 경우, 비용이 큰 계산을 최적화 할 때 사용된다.
> [feat: 필터링된 강의 목록과 전공 목록 메모이제이션](https://github.com/hanghae-plus/front_6th_chapter4-2/pull/26/commits/a97dd13e96fdebbe03622827c19a10bcc13fa1b4) 참조

#### Context의 Provider를 사용해서 상태를 격리하기

`<ScheduleDndProvider>`의 경우 모든 table이 같은 provider 내부에 있어서 하나의 table의 값만 변경되어도 모두 리랜더링이 일어나고 있었다. 이를 provider를 분리해서 상태를 격리하고, 리랜더링이 각 테이블만 일어나도록 수정했다. 

이후 Drop 시 전체 리렌더링이 일어나는 `ScheduleContext`도 비슷한 문제가 있었는데, 이는 아래와 같은 방법으로 해결했다. 

### 코드 품질
#### 가장 기억에 남는 부분: Drop 시 렌더링 최적화

`ScheduleContext`는 모든 테이블의 스케줄 데이터를 하나의 `schedulesMap`으로 관리한다. 고로 Drop 시 `schedulesMap`가 다시 업데이트되고, 이를 구독하는 모든 컴포넌트들에서 리랜더링이 일어나고 있었다.

생각한 해결방안은 다음과 같았다.
1. Context 분리 - 모두 동일한 Context를 사용하는게 문제였기에, 가장 먼저 떠올린 방법. Context를 분리함으로써 구독하던 상태도 분리하면 문제가 해결된다.
2. zustand 사용
3. 메모이제이션만으로 해결
4. State에 주입 ✅ - 사실 재밌는 방법이라고 생각해서 선택했다. 전역으로 있는 상태를 TableWrapper로 각 Table마다 state를 만들어 준 다음 상태를 주입하고, 그 다음부터는 각 테이블별로 상태를 관리하도록 구현했다.  

```typescript
// ScheduleContext.tsx
interface ScheduleContextType {
  initialSchedulesMap: Record<string, Schedule[]>; // 초기값만 제공
  //...
}
```
```typescript
// TableWrapper.tsx - 각 테이블별 독립 상태
const TableWrapper = ({ tableId, index }: TableWrapperProps) => {
  const { initialSchedulesMap, duplicateTable, removeTable } = useScheduleContext();
  
  // 각 테이블마다 독립적인 로컬 state
  const [schedules, setSchedules] = useState<Schedule[]>(
    initialSchedulesMap[tableId] || []
  );

  // 로컬 상태 변경 함수들
  const handleScheduleAdd = useCallback((newSchedules: Schedule[]) => {
    setSchedules(prev => [...prev, ...newSchedules]); // 자신의 state만 변경
  }, []);

  return (
    <ScheduleDndProvider 
      schedules={schedules} 
      onSchedulesChange={setSchedules}
    >
      {/* 테이블 UI */}
    </ScheduleDndProvider>
  );
};
```

다만 메모리측면에서 같은 상태를 context와 state 양쪽에서 가지고 있어야 한다는 점, 그리고 전역 상태가 아닌 로컬 상태로 만들어서 관리하는 방법인데 전역상태가 필요하다면 골치아파지기에 실제 프로덕트였다면 zustand를 사용했을 것 같다.

### 학습 효과 분석
가장 아쉬운 점은 지난 회사에서 대용량 데이터로 차트를 그릴 일이 많았는데, 그때는 이런 성능 최적화 기법들을 알고 있지 못했다는 점이다. 그 당시에는 메모이제이션 기법 조차도 명확하게 이해하지 못해서 사용을 꺼려했었다. 

이제는 어떤 최적화 기법들이 있고, 왜 사용해야 하는지와 언제 사용해야하는지를 익혔기에 조금씩이나마 사용할 수 있을 것 같다. 

#### as-is
- useCallback, useMemo, React.memo 등의 메모이제이션 기법을 정확히 알고 사용하지 못함
- 컴포넌트를 적절하게 나누는 것이 성능 최적화에도 영향을 미치는 것을 알지 못함
#### to-be
- 메모이제이션 기법을 언제, 왜 사용해야하는지 이해함
- 성능 최적화를 위해 컴포넌트를 적절하게 나눌 수 있음

### 과제 피드백
<!-- 예시
- 과제에서 모호하거나 애매했던 부분
- 과제에서 좋았던 부분
-->

## 리뷰 받고 싶은 내용
이번 과제를 진행하면서 이제 useCallback과 React.memo의 경우에는 감이 잡히는 것 같습니다. 하지만 useMemo의 경우에는 아직 좀 아리송한데요. useMemo는 그냥 단순히 계산이 큰 값을 메모이제이션 하는 것 외에는 사용방법이 없는지가 궁금합니다. 
또, [react 공홈](https://ko.react.dev/reference/react/useMemo)에서는 useMemo의 경우 계산에 1ms이상이 걸릴 때, useMemo를 사용하는 것을 권장한다는데, 실제로 코치님의 경우에는 이걸 측정하면서 사용하시나요...?